### PR TITLE
Support for Regular XPC services

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ private func bedazzle(message: String) throws -> Bool {
 
 If this program is a helper tool installed by `SMJobBless`, then in many cases it can be initialized automatically:
 ```swift
-let server = XPCMachServer.forBlessedHelperTool()
+let server = XPCMachServer.forThisBlessedHelperTool()
 ```
 
 ## Client

--- a/Sources/SecureXPC/Client/XPCClient.swift
+++ b/Sources/SecureXPC/Client/XPCClient.swift
@@ -63,19 +63,22 @@ import Foundation
 /// ### Receiving Replies
 /// - ``XPCReplyHandler``
 public class XPCClient {
-    
-    // This client implementation intentionally does not store a reference to the xpc_connection_t as it can become
-    // invalid for numerous reasons. Since it's expected relatively few messages will be sent and the lowest possible
-    // latency isn't needed, it's simpler to always create the connection on demand each time a message is to be sent.
-    
-    private let machServiceName: String
+	// MARK: Public factories
+
+	public static func forMachService(named machServiceName: String) -> XPCClient {
+		XPCMachClient(serviceName: machServiceName)
+	}
+
+	// MARK: Implementation
+
+    internal let serviceName: String
     
     /// Creates a client which will attempt to send messages to the specified mach service.
     ///
     /// - Parameters:
     ///   - machServiceName: The name of the XPC mach service; no validation is performed on this.
-    public init(machServiceName: String) {
-        self.machServiceName = machServiceName
+    internal init(serviceName: String) {
+        self.serviceName = serviceName
     }
     
     /// Receives the result of an XPC send. The result is either an instance of the reply type on success or an ``XPCError`` on failure.
@@ -160,16 +163,11 @@ public class XPCClient {
             reply(result)
         })
     }
-    
+
+	// MARK: Abstract methods
+	
     /// Creates and returns connection for the mach service stored by this instance of the client.
-    private func createConnection() -> xpc_connection_t {
-        let connection = xpc_connection_create_mach_service(self.machServiceName, nil, 0)
-        xpc_connection_set_event_handler(connection, { (event: xpc_object_t) in
-            // A block *must* be set as the handler, even though this block does nothing.
-            // If it were not set, a crash would occur upon calling xpc_connection_resume.
-        })
-        xpc_connection_resume(connection)
-        
-        return connection
+    internal func createConnection() -> xpc_connection_t {
+        fatalError("Abstract Method")
     }
 }

--- a/Sources/SecureXPC/Client/XPCClient.swift
+++ b/Sources/SecureXPC/Client/XPCClient.swift
@@ -7,12 +7,12 @@
 
 import Foundation
 
-/// An XPC Mach Services client to call and receive responses from ``XPCMachServer``.
+/// An XPC client to call and receive responses from an ``XPCServer``.
 ///
 /// ### Calling Routes
 /// Calling a route is as simple creating a client and invoking `send` with a route:
 /// ```swift
-/// let client = XPCMachClient(machServiceName: "com.example.service")
+/// let client = XPCClient.forMachService(named: "com.example.service")
 /// let resetRoute = XPCRouteWithoutMessageWithoutReply("reset")
 /// try client.send(route: resetRoute)
 /// ```
@@ -21,7 +21,7 @@ import Foundation
 /// received by a server, no error will be raised due to how XPC is designed. If it is important for your code to have confirmation of receipt then a route with a reply
 /// should be used:
 /// ```swift
-/// let client = XPCMachClient(machServiceName: "com.example.service")
+/// let client = XPCClient.forMachService(named: "com.example.service")
 /// let resetRoute = XPCRouteWithoutMessageWithReply("reset", replyType: Bool.self)
 /// try client.send(route: resetRoute, withReply: { result in
 ///     switch result {
@@ -33,13 +33,13 @@ import Foundation
 /// })
 /// ```
 ///
-/// The ``XPCMachClient/XPCReplyHandler`` provided to the `withReply` parameter is always passed a
+/// The ``XPCClient/XPCReplyHandler`` provided to the `withReply` parameter is always passed a
 /// [`Result`](https://developer.apple.com/documentation/swift/result) with the `Success` value matching the route's `replyType` and a
 ///  `Failure` of type ``XPCError``. If an error was thrown by the server while handling the request, it will be provided as an ``XPCError`` on failure.
 ///
 /// When calling a route, there is also the option to include a message:
 /// ```swift
-/// let client = XPCMachClient(machServiceName: "com.example.service")
+/// let client = XPCClient.forMachService(named: "com.example.service")
 /// let updateConfigRoute = XPCRouteWithMessageWithReply("update", "config",
 ///                                                      messageType: Config.self,
 ///                                                      replyType: Config.self)
@@ -54,7 +54,8 @@ import Foundation
 ///
 /// ## Topics
 /// ### Creating a Client
-/// - ``init(machServiceName:)``
+/// - ``forMachService(named:)``
+/// - ``forXPCService(named:)``
 /// ### Calling Routes
 /// - ``send(route:)``
 /// - ``send(route:withReply:)``
@@ -80,7 +81,7 @@ public class XPCClient {
     /// Creates a client which will attempt to send messages to the specified mach service.
     ///
     /// - Parameters:
-    ///   - machServiceName: The name of the XPC mach service; no validation is performed on this.
+    ///   - serviceName: The name of the XPC service; no validation is performed on this.
     internal init(serviceName: String) {
         self.serviceName = serviceName
     }
@@ -169,8 +170,8 @@ public class XPCClient {
     }
 
 	// MARK: Abstract methods
-	
-    /// Creates and returns connection for the mach service stored by this instance of the client.
+
+	/// Creates and returns a connection for the service represented by this client.
     internal func createConnection() -> xpc_connection_t {
         fatalError("Abstract Method")
     }

--- a/Sources/SecureXPC/Client/XPCClient.swift
+++ b/Sources/SecureXPC/Client/XPCClient.swift
@@ -1,5 +1,5 @@
 //
-//  XPCMachClient.swift
+//  XPCClient.swift
 //  SecureXPC
 //
 //  Created by Josh Kaplan on 2021-10-09
@@ -62,7 +62,7 @@ import Foundation
 /// - ``sendMessage(_:route:withReply:)``
 /// ### Receiving Replies
 /// - ``XPCReplyHandler``
-public class XPCMachClient {
+public class XPCClient {
     
     // This client implementation intentionally does not store a reference to the xpc_connection_t as it can become
     // invalid for numerous reasons. Since it's expected relatively few messages will be sent and the lowest possible

--- a/Sources/SecureXPC/Client/XPCClient.swift
+++ b/Sources/SecureXPC/Client/XPCClient.swift
@@ -69,6 +69,10 @@ public class XPCClient {
 		XPCMachClient(serviceName: machServiceName)
 	}
 
+	public static func forXPCService(named xpcServiceName: String) -> XPCClient {
+		XPCServiceClient(serviceName: xpcServiceName)
+	}
+
 	// MARK: Implementation
 
     internal let serviceName: String

--- a/Sources/SecureXPC/Client/XPCMachClient.swift
+++ b/Sources/SecureXPC/Client/XPCMachClient.swift
@@ -1,0 +1,26 @@
+//
+//  XPCMachClient.swift
+//  SecureXPC
+//
+//  Created by Josh Kaplan on 2021-10-09
+//
+
+import Foundation
+
+internal class XPCMachClient: XPCClient {
+	/// Creates and returns a connection for the Mach service represented by this client.
+	/// 
+	/// - Note: This client implementation intentionally does not store a reference to the ``xpc_connection_t`` as it can become
+	/// invalid for numerous reasons. Since it's expected relatively few messages will be sent and the lowest possible
+	/// latency isn't needed, it's simpler to always create the connection on demand each time a message is to be sent.
+	internal override func createConnection() -> xpc_connection_t {
+		let connection = xpc_connection_create_mach_service(self.serviceName, nil, 0)
+		xpc_connection_set_event_handler(connection, { (event: xpc_object_t) in
+			// A block *must* be set as the handler, even though this block does nothing.
+			// If it were not set, a crash would occur upon calling xpc_connection_resume.
+		})
+		xpc_connection_resume(connection)
+
+		return connection
+	}
+}

--- a/Sources/SecureXPC/Client/XPCServiceClient.swift
+++ b/Sources/SecureXPC/Client/XPCServiceClient.swift
@@ -1,0 +1,26 @@
+//
+//  XPCServiceClient.swift
+//  
+//
+//  Created by Alexander Momchilov on 2021-11-08.
+//
+
+import Foundation
+
+internal class XPCServiceClient: XPCClient {
+	/// Creates and returns connection for the mach service stored by this instance of the client.
+	///
+	/// - Note: This client implementation intentionally does not store a reference to the ``xpc_connection_t`` as it can become
+	/// invalid for numerous reasons. Since it's expected relatively few messages will be sent and the lowest possible
+	/// latency isn't needed, it's simpler to always create the connection on demand each time a message is to be sent.
+	internal override func createConnection() -> xpc_connection_t {
+		let connection = xpc_connection_create(self.serviceName, nil)
+		xpc_connection_set_event_handler(connection, { (event: xpc_object_t) in
+			// A block *must* be set as the handler, even though this block does nothing.
+			// If it were not set, a crash would occur upon calling xpc_connection_resume.
+		})
+		xpc_connection_resume(connection)
+
+		return connection
+	}
+}

--- a/Sources/SecureXPC/Client/XPCServiceClient.swift
+++ b/Sources/SecureXPC/Client/XPCServiceClient.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 internal class XPCServiceClient: XPCClient {
-	/// Creates and returns connection for the mach service stored by this instance of the client.
+	/// Creates and returns a connection for the XPC service represented by this client.
 	///
 	/// - Note: This client implementation intentionally does not store a reference to the ``xpc_connection_t`` as it can become
 	/// invalid for numerous reasons. Since it's expected relatively few messages will be sent and the lowest possible

--- a/Sources/SecureXPC/SecureXPC.docc/Routes.md
+++ b/Sources/SecureXPC/SecureXPC.docc/Routes.md
@@ -43,7 +43,7 @@ Take care when updating existing routes because over time you may end up with an
 on a computer with a newer client.
 
 #### Registering Routes
-See ``XPCMachServer``.
+See ``XPCServer``.
 
 #### Calling Routes
-See ``XPCMachClient``.
+See ``XPCClient``.

--- a/Sources/SecureXPC/SecureXPC.docc/SecureXPC.md
+++ b/Sources/SecureXPC/SecureXPC.docc/SecureXPC.md
@@ -41,9 +41,9 @@ private func bedazzle(message: String) throws -> Bool {
 ```
 
 If this program is a helper tool installed by `SMJobBless`, then in many cases it can be initialized automatically with
-``XPCMachServer/forBlessedHelperTool()``.
+``XPCServer/forThisBlessedHelperTool()``.
 
-See ``XPCMachServer`` for details on how to create, configure, and start a server.
+See ``XPCServer`` for details on how to create, configure, and start a server.
 
 #### Client
 
@@ -59,12 +59,12 @@ try client.sendMessage("Get Schwifty", route: route, withReply: { result in
     }
 })
 ```
-See ``XPCMachClient`` for more on how to send with a client.
+See ``XPCClient`` for more on how to send with a client.
 
 ## Topics
 ### Client and Server
-- ``XPCMachClient``
-- ``XPCMachServer``
+- ``XPCClient``
+- ``XPCServer``
 
 ### Routes
 - <doc:/Routes>

--- a/Sources/SecureXPC/Server/XPCMachServer.swift
+++ b/Sources/SecureXPC/Server/XPCMachServer.swift
@@ -1,0 +1,208 @@
+//
+//  XPCMachServer.swift
+//  
+//
+//  Created by Alexander Momchilov on 2021-11-08.
+//
+
+import Foundation
+
+public class XPCMachServer: XPCServer {
+	private let machService: xpc_connection_t
+	private let clientRequirements: [SecRequirement]
+
+	/// Creates a server that accepts requests from clients which meet the security requirements.
+	///
+	/// Because many processes on the system can talk to an XPC Mach Service, when creating a server it is required that you specifiy the security requirements
+	/// of any connecting clients:
+	/// ```swift
+	/// let reqString = """identifier "com.example.AuthorizedClient" and certificate leaf[subject.OU] = "4L0ZG128MM" """
+	/// var requirement: SecRequirement?
+	/// if SecRequirementCreateWithString(reqString as CFString,
+	///                                   SecCSFlags(),
+	///                                   &requirement) == errSecSuccess,
+	///   let requirement = requirement {
+	///    let server = XPCMachServer(machServiceName: "com.example.service",
+	///                               clientRequirements: [requirement])
+	///
+	///    <# configure and start server #>
+	/// }
+	/// ```
+	///
+	/// > Important: No requests will be processed until ``start()`` is called.
+	///
+	/// - Parameters:
+	///   - machServiceName: The name of the mach service this server should bind to. This name must be present in this program's launchd property list's
+	///                      `MachServices` entry.
+	///   - clientRequirements: If a request is received from a client, it will only be processed if it meets one (or more) of these security requirements.
+	public init(machServiceName: String, clientRequirements: [SecRequirement]) {
+		self.clientRequirements = clientRequirements
+
+		self.machService = machServiceName.withCString { serviceNamePointer in
+			return xpc_connection_create_mach_service(
+				serviceNamePointer,
+				nil, // targetq: DispatchQueue, defaults to using DISPATCH_TARGET_QUEUE_DEFAULT
+				UInt64(XPC_CONNECTION_MACH_SERVICE_LISTENER))
+		}
+	}
+
+	/// Initializes a server for a helper tool that meets
+	/// [`SMJobBless`](https://developer.apple.com/documentation/servicemanagement/1431078-smjobbless) requirements.
+	///
+	/// To successfully call this function the following requirements must be met:
+	///   - The launchd property list embedded in this helper tool must have exactly one entry for its `MachServices` dictionary
+	///   - The info property list embedded in this helper tool must have at least one element in its
+	///   [`SMAuthorizedClients`](https://developer.apple.com/documentation/bundleresources/information_property_list/smauthorizedclients)
+	///   array
+	///   - Every element in the `SMAuthorizedClients` array must be a valid security requirement
+	///     - To be valid, it must be creatable by
+	///     [`SecRequirementCreateWithString`](https://developer.apple.com/documentation/security/1394522-secrequirementcreatewithstring)
+	///
+	/// Incoming requests will be accepted from clients that meet _any_ of the `SMAuthorizedClients` requirements.
+	///
+	/// > Important: No requests will be processed until ``start()`` is called.
+	///
+	/// - Returns: A server instance initialized with the embedded property list entries.
+	public static func forBlessedHelperTool() throws -> XPCMachServer {
+		// Determine mach service name launchd property list's MachServices
+		var machServiceName: String
+		let launchdData = try readEmbeddedPropertyList(sectionName: "__launchd_plist")
+		let launchdPropertyList = try PropertyListSerialization.propertyList(
+			from: launchdData,
+			options: .mutableContainersAndLeaves,
+			format: nil) as? NSDictionary
+		if let machServices = launchdPropertyList?["MachServices"] as? [String : Any] {
+			if machServices.count == 1, let name = machServices.first?.key {
+				machServiceName = name
+			} else {
+				throw XPCError.misconfiguredBlessedHelperTool("MachServices dictionary does not have exactly one entry")
+			}
+		} else {
+			throw XPCError.misconfiguredBlessedHelperTool("launchd property list missing MachServices key")
+		}
+
+		// Generate client requirements from info property list's SMAuthorizedClients
+		var clientRequirements = [SecRequirement]()
+		let infoData = try readEmbeddedPropertyList(sectionName: "__info_plist")
+		let infoPropertyList = try PropertyListSerialization.propertyList(
+			from: infoData,
+			options: .mutableContainersAndLeaves,
+			format: nil) as? NSDictionary
+		if let authorizedClients = infoPropertyList?["SMAuthorizedClients"] as? [String] {
+			for client in authorizedClients {
+				var requirement: SecRequirement?
+				if SecRequirementCreateWithString(client as CFString, SecCSFlags(), &requirement) == errSecSuccess,
+				   let requirement = requirement {
+					clientRequirements.append(requirement)
+				} else {
+					throw XPCError.misconfiguredBlessedHelperTool("Invalid SMAuthorizedClients requirement: \(client)")
+				}
+			}
+		} else {
+			throw XPCError.misconfiguredBlessedHelperTool("Info property list missing SMAuthorizedClients key")
+		}
+		if clientRequirements.isEmpty {
+			throw XPCError.misconfiguredBlessedHelperTool("No requirements were generated from SMAuthorizedClients")
+		}
+
+		return XPCMachServer(machServiceName: machServiceName, clientRequirements: clientRequirements)
+	}
+
+	/// Read the property list embedded within this helper tool.
+	///
+	/// - Returns: The property list as data.
+	private static func readEmbeddedPropertyList(sectionName: String) throws -> Data {
+		// By passing in nil, this returns a handle for the dynamic shared object (shared library) for this helper tool
+		if let handle = dlopen(nil, RTLD_LAZY) {
+			defer { dlclose(handle) }
+
+			if let mhExecutePointer = dlsym(handle, MH_EXECUTE_SYM) {
+				let mhExecuteBoundPointer = mhExecutePointer.assumingMemoryBound(to: mach_header_64.self)
+
+				var size = UInt(0)
+				if let section = getsectiondata(mhExecuteBoundPointer, "__TEXT", sectionName, &size) {
+					return Data(bytes: section, count: Int(size))
+				} else { // No section found with the name corresponding to the property list
+					throw XPCError.misconfiguredBlessedHelperTool("Missing property list section \(sectionName)")
+				}
+			} else { // Can't get pointer to MH_EXECUTE_SYM
+				throw XPCError.misconfiguredBlessedHelperTool("Could not read property list (nil symbol pointer)")
+			}
+		} else { // Can't open handle
+			throw XPCError.misconfiguredBlessedHelperTool("Could not read property list (handle not openable)")
+		}
+	}
+
+	public override func start() -> Never {
+		// Start listener for the mach service, all received events should be for incoming connections
+		 xpc_connection_set_event_handler(self.machService, { connection in
+			 // Listen for events (messages or errors) coming from this connection
+			 xpc_connection_set_event_handler(connection, { event in
+				 self.handleEvent(connection: connection, event: event)
+			 })
+			 xpc_connection_resume(connection)
+		 })
+		 xpc_connection_resume(self.machService)
+
+		 dispatchMain()
+	}
+
+	internal override func acceptMessage(connection: xpc_connection_t, message: xpc_object_t) -> Bool {
+		// Get the code representing the client
+		var code: SecCode?
+		if #available(macOS 11, *) { // publicly documented, but only available since macOS 11
+			SecCodeCreateWithXPCMessage(message, SecCSFlags(), &code)
+		} else { // private undocumented function: xpc_connection_get_audit_token, available on prior versions of macOS
+			if var auditToken = xpc_connection_get_audit_token(connection) {
+				let tokenData = NSData(bytes: &auditToken, length: MemoryLayout.size(ofValue: auditToken))
+				let attributes = [kSecGuestAttributeAudit : tokenData] as NSDictionary
+				SecCodeCopyGuestWithAttributes(nil, attributes, SecCSFlags(), &code)
+			}
+		}
+
+		// Accept message if code is valid and meets any of the client requirements
+		var accept = false
+		if let code = code {
+			for requirement in self.clientRequirements {
+				if SecCodeCheckValidity(code, SecCSFlags(), requirement) == errSecSuccess {
+					accept = true
+				}
+			}
+		}
+
+		return accept
+	}
+
+	/// Wrapper around the private undocumented function `void xpc_connection_get_audit_token(xpc_connection_t, audit_token_t *)`.
+	///
+	/// The private undocumented function will attempt to be dynamically loaded and then invoked. If no function exists with this name `nil` will be returned. If
+	/// the function does exist, but does not match the expected signature, the process calling this function is expected to crash. However, because this is only
+	/// called on older versions of macOS which are expected to have a stable non-changing API this is very unlikely to occur.
+	///
+	/// - Parameters:
+	///   - _:  The connection for which the audit token will be retrieved for.
+	/// - Returns: The audit token or `nil` if the function could not be called.
+	private func xpc_connection_get_audit_token(_ connection: xpc_connection_t) -> audit_token_t? {
+		typealias functionSignature = @convention(c) (xpc_connection_t, UnsafeMutablePointer<audit_token_t>) -> Void
+		let auditToken: audit_token_t?
+
+		// Attempt to dynamically load the function
+		if let handle = dlopen(nil, RTLD_LAZY) {
+			defer { dlclose(handle) }
+			if let sym = dlsym(handle, "xpc_connection_get_audit_token") {
+				let function = unsafeBitCast(sym, to: functionSignature.self)
+
+				// Call the function
+				var token = audit_token_t()
+				function(connection, &token)
+				auditToken = token
+			} else {
+				auditToken = nil
+			}
+		} else {
+			auditToken = nil
+		}
+
+		return auditToken
+	}
+}

--- a/Sources/SecureXPC/Server/XPCMachServer.swift
+++ b/Sources/SecureXPC/Server/XPCMachServer.swift
@@ -7,35 +7,11 @@
 
 import Foundation
 
-public class XPCMachServer: XPCServer {
+internal class XPCMachServer: XPCServer {
 	private let machService: xpc_connection_t
 	private let clientRequirements: [SecRequirement]
 
-	/// Creates a server that accepts requests from clients which meet the security requirements.
-	///
-	/// Because many processes on the system can talk to an XPC Mach Service, when creating a server it is required that you specifiy the security requirements
-	/// of any connecting clients:
-	/// ```swift
-	/// let reqString = """identifier "com.example.AuthorizedClient" and certificate leaf[subject.OU] = "4L0ZG128MM" """
-	/// var requirement: SecRequirement?
-	/// if SecRequirementCreateWithString(reqString as CFString,
-	///                                   SecCSFlags(),
-	///                                   &requirement) == errSecSuccess,
-	///   let requirement = requirement {
-	///    let server = XPCMachServer(machServiceName: "com.example.service",
-	///                               clientRequirements: [requirement])
-	///
-	///    <# configure and start server #>
-	/// }
-	/// ```
-	///
-	/// > Important: No requests will be processed until ``start()`` is called.
-	///
-	/// - Parameters:
-	///   - machServiceName: The name of the mach service this server should bind to. This name must be present in this program's launchd property list's
-	///                      `MachServices` entry.
-	///   - clientRequirements: If a request is received from a client, it will only be processed if it meets one (or more) of these security requirements.
-	public init(machServiceName: String, clientRequirements: [SecRequirement]) {
+	internal init(machServiceName: String, clientRequirements: [SecRequirement]) {
 		self.clientRequirements = clientRequirements
 
 		self.machService = machServiceName.withCString { serviceNamePointer in
@@ -46,24 +22,7 @@ public class XPCMachServer: XPCServer {
 		}
 	}
 
-	/// Initializes a server for a helper tool that meets
-	/// [`SMJobBless`](https://developer.apple.com/documentation/servicemanagement/1431078-smjobbless) requirements.
-	///
-	/// To successfully call this function the following requirements must be met:
-	///   - The launchd property list embedded in this helper tool must have exactly one entry for its `MachServices` dictionary
-	///   - The info property list embedded in this helper tool must have at least one element in its
-	///   [`SMAuthorizedClients`](https://developer.apple.com/documentation/bundleresources/information_property_list/smauthorizedclients)
-	///   array
-	///   - Every element in the `SMAuthorizedClients` array must be a valid security requirement
-	///     - To be valid, it must be creatable by
-	///     [`SecRequirementCreateWithString`](https://developer.apple.com/documentation/security/1394522-secrequirementcreatewithstring)
-	///
-	/// Incoming requests will be accepted from clients that meet _any_ of the `SMAuthorizedClients` requirements.
-	///
-	/// > Important: No requests will be processed until ``start()`` is called.
-	///
-	/// - Returns: A server instance initialized with the embedded property list entries.
-	public static func forBlessedHelperTool() throws -> XPCMachServer {
+	internal static func _forThisBlessedHelperTool() throws -> XPCMachServer {
 		// Determine mach service name launchd property list's MachServices
 		var machServiceName: String
 		let launchdData = try readEmbeddedPropertyList(sectionName: "__launchd_plist")

--- a/Sources/SecureXPC/Server/XPCServer.swift
+++ b/Sources/SecureXPC/Server/XPCServer.swift
@@ -131,6 +131,10 @@ public class XPCServer {
 		try XPCMachServer._forThisBlessedHelperTool()
 	}
 
+	public static func forThisXPCService() -> XPCServer {
+		XPCServiceServer.service
+	}
+
 	// MARK: Implementation
 
     /// If set, errors encountered will be sent to this handler.

--- a/Sources/SecureXPC/Server/XPCServer.swift
+++ b/Sources/SecureXPC/Server/XPCServer.swift
@@ -75,138 +75,16 @@ import Foundation
 ///
 /// ### Error Handling
 /// - ``errorHandler``
-public class XPCBaseServer {
+public class XPCServer {
     
     /// If set, errors encountered will be sent to this handler.
     public var errorHandler: ((XPCError) -> Void)?
-    
-    private let machService: xpc_connection_t
-    private let clientRequirements: [SecRequirement]
     
     // Routes
     private var routesWithoutMessageWithReply = [XPCRoute : XPCHandlerWithoutMessageWithReply]()
     private var routesWithMessageWithReply = [XPCRoute : XPCHandlerWithMessageWithReply]()
     private var routesWithoutMessageWithoutReply = [XPCRoute : XPCHandlerWithoutMessageWithoutReply]()
     private var routesWithMessageWithoutReply = [XPCRoute : XPCHandlerWithMessageWithoutReply]()
-    
-    /// Creates a server that accepts requests from clients which meet the security requirements.
-    ///
-    /// Because many processes on the system can talk to an XPC Mach Service, when creating a server it is required that you specifiy the security requirements
-    /// of any connecting clients:
-    /// ```swift
-    /// let reqString = """identifier "com.example.AuthorizedClient" and certificate leaf[subject.OU] = "4L0ZG128MM" """
-    /// var requirement: SecRequirement?
-    /// if SecRequirementCreateWithString(reqString as CFString,
-    ///                                   SecCSFlags(),
-    ///                                   &requirement) == errSecSuccess,
-    ///   let requirement = requirement {
-    ///    let server = XPCMachServer(machServiceName: "com.example.service",
-    ///                               clientRequirements: [requirement])
-    ///
-    ///    <# configure and start server #>
-    /// }
-    /// ```
-    ///
-    /// > Important: No requests will be processed until ``start()`` is called.
-    ///
-    /// - Parameters:
-    ///   - machServiceName: The name of the mach service this server should bind to. This name must be present in this program's launchd property list's
-    ///                      `MachServices` entry.
-    ///   - clientRequirements: If a request is received from a client, it will only be processed if it meets one (or more) of these security requirements.
-    public init(machServiceName: String, clientRequirements: [SecRequirement]) {
-        self.clientRequirements = clientRequirements
-        
-        self.machService = machServiceName.withCString { serviceNamePointer in
-            return xpc_connection_create_mach_service(serviceNamePointer,
-                                                      nil,
-                                                      UInt64(XPC_CONNECTION_MACH_SERVICE_LISTENER))
-        }
-    }
-    
-    /// Initializes a server for a helper tool that meets
-    /// [`SMJobBless`](https://developer.apple.com/documentation/servicemanagement/1431078-smjobbless) requirements.
-    ///
-    /// To successfully call this function the following requirements must be met:
-    ///   - The launchd property list embedded in this helper tool must have exactly one entry for its `MachServices` dictionary
-    ///   - The info property list embedded in this helper tool must have at least one element in its
-    ///   [`SMAuthorizedClients`](https://developer.apple.com/documentation/bundleresources/information_property_list/smauthorizedclients)
-    ///   array
-    ///   - Every element in the `SMAuthorizedClients` array must be a valid security requirement
-    ///     - To be valid, it must be creatable by
-    ///     [`SecRequirementCreateWithString`](https://developer.apple.com/documentation/security/1394522-secrequirementcreatewithstring)
-    ///
-    /// Incoming requests will be accepted from clients that meet _any_ of the `SMAuthorizedClients` requirements.
-    ///
-    /// > Important: No requests will be processed until ``start()`` is called.
-    ///
-    /// - Returns: A server instance initialized with the embedded property list entries.
-    public static func forBlessedHelperTool() throws -> XPCMachServer {
-        // Determine mach service name launchd property list's MachServices
-        var machServiceName: String
-        let launchdData = try readEmbeddedPropertyList(sectionName: "__launchd_plist")
-        let launchdPropertyList = try PropertyListSerialization.propertyList(from: launchdData,
-                                                                             options: .mutableContainersAndLeaves,
-                                                                             format: nil) as? NSDictionary
-        if let machServices = launchdPropertyList?["MachServices"] as? [String : Any] {
-            if machServices.count == 1, let name = machServices.first?.key {
-                machServiceName = name
-            } else {
-                throw XPCError.misconfiguredBlessedHelperTool("MachServices dictionary does not have exactly one entry")
-            }
-        } else {
-            throw XPCError.misconfiguredBlessedHelperTool("launchd property list missing MachServices key")
-        }
-        
-        // Generate client requirements from info property list's SMAuthorizedClients
-        var clientRequirements = [SecRequirement]()
-        let infoData = try readEmbeddedPropertyList(sectionName: "__info_plist")
-        let infoPropertyList = try PropertyListSerialization.propertyList(from: infoData,
-                                                                          options: .mutableContainersAndLeaves,
-                                                                          format: nil) as? NSDictionary
-        if let authorizedClients = infoPropertyList?["SMAuthorizedClients"] as? [String] {
-            for client in authorizedClients {
-                var requirement: SecRequirement?
-                if SecRequirementCreateWithString(client as CFString, SecCSFlags(), &requirement) == errSecSuccess,
-                   let requirement = requirement {
-                    clientRequirements.append(requirement)
-                } else {
-                    throw XPCError.misconfiguredBlessedHelperTool("Invalid SMAuthorizedClients requirement: \(client)")
-                }
-            }
-        } else {
-            throw XPCError.misconfiguredBlessedHelperTool("Info property list missing SMAuthorizedClients key")
-        }
-        if clientRequirements.isEmpty {
-            throw XPCError.misconfiguredBlessedHelperTool("No requirements were generated from SMAuthorizedClients")
-        }
-        
-        return XPCMachServer(machServiceName: machServiceName, clientRequirements: clientRequirements)
-    }
-    
-    /// Read the property list embedded within this helper tool.
-    ///
-    /// - Returns: The property list as data.
-    private static func readEmbeddedPropertyList(sectionName: String) throws -> Data {
-        // By passing in nil, this returns a handle for the dynamic shared object (shared library) for this helper tool
-        if let handle = dlopen(nil, RTLD_LAZY) {
-            defer { dlclose(handle) }
-
-            if let mhExecutePointer = dlsym(handle, MH_EXECUTE_SYM) {
-                let mhExecuteBoundPointer = mhExecutePointer.assumingMemoryBound(to: mach_header_64.self)
-
-                var size = UInt(0)
-                if let section = getsectiondata(mhExecuteBoundPointer, "__TEXT", sectionName, &size) {
-                    return Data(bytes: section, count: Int(size))
-                } else { // No section found with the name corresponding to the property list
-                    throw XPCError.misconfiguredBlessedHelperTool("Missing property list section \(sectionName)")
-                }
-            } else { // Can't get pointer to MH_EXECUTE_SYM
-                throw XPCError.misconfiguredBlessedHelperTool("Could not read property list (nil symbol pointer)")
-            }
-        } else { // Can't open handle
-            throw XPCError.misconfiguredBlessedHelperTool("Could not read property list (handle not openable)")
-        }
-    }
     
     /// Registers a route that has no message and can't receive a reply.
     ///
@@ -260,25 +138,7 @@ public class XPCBaseServer {
         self.routesWithMessageWithReply[route.route] = handlerWrapper
     }
     
-    /// Begins processing requests received by this XPC server.
-    ///
-    /// This function replicates [`xpc_main()`](https://developer.apple.com/documentation/xpc/1505740-xpc_main) behavior by never
-    /// returning.
-    public func start() -> Never {
-        // Start listener for the mach service, all received events should be for incoming connections
-        xpc_connection_set_event_handler(self.machService, { connection in
-            // Listen for events (messages or errors) coming from this connection
-            xpc_connection_set_event_handler(connection, { event in
-                self.handleEvent(connection: connection, event: event)
-            })
-            xpc_connection_resume(connection)
-        })
-        xpc_connection_resume(self.machService)
-        
-        dispatchMain()
-    }
-    
-    private func handleEvent(connection: xpc_connection_t, event: xpc_object_t) {
+    internal func handleEvent(connection: xpc_connection_t, event: xpc_object_t) {
         if xpc_get_type(event) == XPC_TYPE_DICTIONARY {
             if self.acceptMessage(connection: connection, message: event) {
                 var reply = xpc_dictionary_create_reply(event)
@@ -312,72 +172,6 @@ public class XPCBaseServer {
         } else {
             self.errorHandler?(XPCError.unknown)
         }
-    }
-    
-    /// Determines whether the message should be accepted.
-    ///
-    /// This is determined using the client requirements provided to this server upon initialization.
-    /// - Parameters:
-    ///   - connection: The connection the message was sent over.
-    ///   - message: The message.
-    /// - Returns: whether the message can be accepted
-    private func acceptMessage(connection: xpc_connection_t, message: xpc_object_t) -> Bool {
-        // Get the code representing the client
-        var code: SecCode?
-        if #available(macOS 11, *) { // publicly documented, but only available since macOS 11
-            SecCodeCreateWithXPCMessage(message, SecCSFlags(), &code)
-        } else { // private undocumented function: xpc_connection_get_audit_token, available on prior versions of macOS
-            if var auditToken = xpc_connection_get_audit_token(connection) {
-                let tokenData = NSData(bytes: &auditToken, length: MemoryLayout.size(ofValue: auditToken))
-                let attributes = [kSecGuestAttributeAudit : tokenData] as NSDictionary
-                SecCodeCopyGuestWithAttributes(nil, attributes, SecCSFlags(), &code)
-            }
-        }
-        
-        // Accept message if code is valid and meets any of the client requirements
-        var accept = false
-        if let code = code {
-            for requirement in self.clientRequirements {
-                if SecCodeCheckValidity(code, SecCSFlags(), requirement) == errSecSuccess {
-                    accept = true
-                }
-            }
-        }
-        
-        return accept
-    }
-    
-    /// Wrapper around the private undocumented function `void xpc_connection_get_audit_token(xpc_connection_t, audit_token_t *)`.
-    ///
-    /// The private undocumented function will attempt to be dynamically loaded and then invoked. If no function exists with this name `nil` will be returned. If
-    /// the function does exist, but does not match the expected signature, the process calling this function is expected to crash. However, because this is only
-    /// called on older versions of macOS which are expected to have a stable non-changing API this is very unlikely to occur.
-    ///
-    /// - Parameters:
-    ///   - _:  The connection for which the audit token will be retrieved for.
-    /// - Returns: The audit token or `nil` if the function could not be called.
-    private func xpc_connection_get_audit_token(_ connection: xpc_connection_t) -> audit_token_t? {
-        typealias functionSignature = @convention(c) (xpc_connection_t, UnsafeMutablePointer<audit_token_t>) -> Void
-        let auditToken: audit_token_t?
-        
-        // Attempt to dynamically load the function
-        if let handle = dlopen(nil, RTLD_LAZY) {
-            defer { dlclose(handle) }
-            if let sym = dlsym(handle, "xpc_connection_get_audit_token") {
-                let function = unsafeBitCast(sym, to: functionSignature.self)
-                
-                // Call the function
-                var token = audit_token_t()
-                function(connection, &token)
-                auditToken = token
-            } else {
-                auditToken = nil
-            }
-        } else {
-            auditToken = nil
-        }
-        
-        return auditToken
     }
     
     private func handleMessage(connection: xpc_connection_t, message: xpc_object_t, reply: inout xpc_object_t?) throws {
@@ -427,6 +221,27 @@ public class XPCBaseServer {
             }
         }
     }
+
+	// MARK: Abstract methods
+
+	/// Begins processing requests received by this XPC server.
+	///
+	/// This function replicates [`xpc_main()`](https://developer.apple.com/documentation/xpc/1505740-xpc_main) behavior by never
+	/// returning.
+	public func start() -> Never {
+		fatalError("Abstract Method")
+	}
+
+	/// Determines whether the message should be accepted.
+	///
+	/// This is determined using the client requirements provided to this server upon initialization.
+	/// - Parameters:
+	///   - connection: The connection the message was sent over.
+	///   - message: The message.
+	/// - Returns: whether the message can be accepted
+	internal func acceptMessage(connection: xpc_connection_t, message: xpc_object_t) -> Bool {
+		fatalError("Abstract Method")
+	}
 }
 
 // MARK: handler function wrappers

--- a/Sources/SecureXPC/Server/XPCServer.swift
+++ b/Sources/SecureXPC/Server/XPCServer.swift
@@ -7,28 +7,32 @@
 
 import Foundation
 
-/// An XPC Mach Services server to receive calls from and send responses to ``XPCMachClient``.
+/// An XPC server to receive calls from and send responses to an ``XPCClient``.
 ///
 /// ### Creating a Server
 /// If the program creating this server is a helper tool which meets
 /// [`SMJobBless`](https://developer.apple.com/documentation/servicemanagement/1431078-smjobbless) requirements then in most
 /// cases creating a server is as easy as
 /// ```swift
-/// let server = try XPCMachServer.forBlessedHelperTool()
+/// let server = try XPCServer.forThisBlessedHelperTool()
 /// ```
-/// See ``forBlessedHelperTool()`` for the exact requirements which need to be met.
+/// See ``XPCServer/forThisBlessedHelperTool()`` for the exact requirements which need to be met.
 ///
-/// **Other Cases**
+/// #### Other Mach Services
 ///
 /// Otherwise you'll need to manually initialize a server by specifying the name of the XPC Mach Service and providing the security requirements for connecting
-/// clients. See ``init(machServiceName:clientRequirements:)`` for an example and details.
+/// clients. See ``forMachService(named:clientRequirements:)`` for an example and details.
 ///
 /// **Requirement Checking**
 ///
 /// On macOS 11 and later, requirement checking uses publicly documented APIs. On older versions of macOS, the private undocumented API
 /// `void xpc_connection_get_audit_token(xpc_connection_t, audit_token_t *)` will be used; if for some reason the function is unavailable
-/// then no messages will be accepted. When messages are not accepted, if the ``XPCMachServer/errorHandler`` is set then it is called
+/// then no messages will be accepted. When messages are not accepted, if the ``XPCServer/errorHandler`` is set then it is called
 /// with ``XPCError/insecure``.
+///
+/// #### XPC Services
+///
+/// TODO
 ///
 /// ### Registering & Handling Routes
 /// Once a server instance has been created, one or more routes should be registered with it. This is done by calling one of the `registerRoute` functions and
@@ -61,14 +65,15 @@ import Foundation
 ///
 /// ## Topics
 /// ### Creating a Server
-/// - ``forBlessedHelperTool()``
-/// - ``init(machServiceName:clientRequirements:)``
+/// - ``forThisBlessedHelperTool()``
+/// - ``forMachService(named:clientRequirements:)``
+/// - ``forThisXPCService()``
 ///
 /// ### Registering Routes
-/// - ``registerRoute(_:handler:)-8ydqa``
-/// - ``registerRoute(_:handler:)-76t5b``
-/// - ``registerRoute(_:handler:)-39dgn``
-/// - ``registerRoute(_:handler:)-1rnkw``
+/// - ``registerRoute(_:handler:)-1jw9d``
+/// - ``registerRoute(_:handler:)-4fxv0``
+/// - ``registerRoute(_:handler:)-4ttqe``
+/// - ``registerRoute(_:handler:)-9a0x9``
 ///
 /// ### Starting a Server
 /// - ``start()``

--- a/Sources/SecureXPC/Server/XPCServer.swift
+++ b/Sources/SecureXPC/Server/XPCServer.swift
@@ -1,5 +1,5 @@
 //
-//  XPCMachServer.swift
+//  XPCServer.swift
 //  SecureXPC
 //
 //  Created by Josh Kaplan on 2021-10-09
@@ -75,7 +75,7 @@ import Foundation
 ///
 /// ### Error Handling
 /// - ``errorHandler``
-public class XPCMachServer {
+public class XPCBaseServer {
     
     /// If set, errors encountered will be sent to this handler.
     public var errorHandler: ((XPCError) -> Void)?

--- a/Sources/SecureXPC/Server/XPCServiceServer.swift
+++ b/Sources/SecureXPC/Server/XPCServiceServer.swift
@@ -1,0 +1,29 @@
+//
+//  XPCServiceServer.swift
+//  
+//
+//  Created by Alexander Momchilov on 2021-11-07.
+//
+
+import XPC
+
+internal class XPCServiceServer: XPCServer {
+	internal static let service = XPCServiceServer()
+
+	private override init() {}
+
+	public override func start() -> Never {
+		xpc_main { connection in
+			// Listen for events (messages or errors) coming from this connection
+			xpc_connection_set_event_handler(connection, { event in
+				XPCServiceServer.service.handleEvent(connection: connection, event: event)
+			})
+			xpc_connection_resume(connection)
+		}
+	}
+
+	internal override func acceptMessage(connection: xpc_connection_t, message: xpc_object_t) -> Bool {
+		// XPC services are application-scoped, so we're assuming they're inheritently safe
+		true
+	}
+}

--- a/Sources/SecureXPC/XPCError.swift
+++ b/Sources/SecureXPC/XPCError.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-/// Errors that may be thrown when using ``XPCMachClient`` or ``XPCMachServer``.
+/// Errors that may be thrown when using ``XPCClient`` or ``XPCServer``.
 public enum XPCError: Error, Codable {
     /// The connection was closed and can no longer be used; it may be possible to establish another connection.
     ///
@@ -40,9 +40,9 @@ public enum XPCError: Error, Codable {
     case decodingError(String)
     /// The route associated with the incoming XPC request is not registed with the server.
     case routeNotRegistered(String)
-    /// The calling program's property list configuration is not compatible with ``XPCMachServer/forBlessedHelperTool()``.
+    /// The calling program's property list configuration is not compatible with ``XPCServer/forThisBlessedHelperTool()``.
     case misconfiguredBlessedHelperTool(String)
-    /// An error occurred that is not part of this framework, for example an error thrown by a handler registered with a ``XPCMachServer`` route. The associated
+    /// An error occurred that is not part of this framework, for example an error thrown by a handler registered with a ``XPCServer`` route. The associated
     /// value describes the error.
     case other(String)
     /// Unknown error occurred.


### PR DESCRIPTION
IDK what the correct nomenclature is, but PR adds support for "regular" (non-Mach) XPC services.

Works great, locally.

~I extracted out `XPCBase(Client|Server)` classes to do most of the work. Perhaps it should be a protocol instead. Though I think it's correct for the client and server types to remain classes, even if they don't end up using inheritance.~

Implemented the design @jakaplan described here: https://github.com/trilemma-dev/SecureXPC/pull/10#pullrequestreview-801087521

WDYT? @jakaplan

TODOs before merging

- [ ] Update docs

