### PR TITLE
Persistent client connections

### DIFF
--- a/Sources/SecureXPC/Client/XPCClient.swift
+++ b/Sources/SecureXPC/Client/XPCClient.swift
@@ -126,9 +126,10 @@ public class XPCClient {
         XPCMachClient(serviceName: machServiceName)
     }
 
-	// MARK: Implementation
+    // MARK: Implementation
 
     internal let serviceName: String
+    private var connection: xpc_connection_t? = nil
     
     /// Creates a client which will attempt to send messages to the specified mach service.
     ///
@@ -209,10 +210,13 @@ public class XPCClient {
                     result = Result.failure(.unknown)
                 }
             } else if xpc_equal(xpcResponse, XPC_ERROR_CONNECTION_INVALID) {
+                self.connection = nil
                 result = Result.failure(.connectionInvalid)
             } else if xpc_equal(xpcResponse, XPC_ERROR_CONNECTION_INTERRUPTED) {
+                self.connection = nil
                 result = Result.failure(.connectionInterrupted)
             } else if xpc_equal(xpcResponse, XPC_ERROR_TERMINATION_IMMINENT) {
+                self.connection = nil
                 result = Result.failure(.terminationImminent)
             } else { // Unexpected
                 result = Result.failure(.unknown)
@@ -222,15 +226,25 @@ public class XPCClient {
     }
 
     private func getConnection() -> xpc_connection_t {
-        let newConnection = self.createConnection()
+        if let existingConnection = self.connection { return existingConnection }
 
-        xpc_connection_set_event_handler(newConnection, { (event: xpc_object_t) in
-            // A block *must* be set as the handler, even though this block does nothing.
-            // If it were not set, a crash would occur upon calling xpc_connection_resume.
-        })
+        let newConnection = self.createConnection()
+        self.connection = newConnection
+
+        xpc_connection_set_event_handler(newConnection, self.handle(connectionEvent:))
         xpc_connection_resume(newConnection)
 
         return newConnection
+    }
+
+    private func handle(connectionEvent: xpc_object_t) {
+        if xpc_equal(connectionEvent, XPC_ERROR_CONNECTION_INVALID) {
+            self.connection = nil
+        } else if xpc_equal(connectionEvent, XPC_ERROR_CONNECTION_INTERRUPTED) {
+            self.connection = nil
+        } else if xpc_equal(connectionEvent, XPC_ERROR_TERMINATION_IMMINENT) {
+            self.connection = nil
+        }
     }
 
     // MARK: Abstract methods

--- a/Sources/SecureXPC/Client/XPCMachClient.swift
+++ b/Sources/SecureXPC/Client/XPCMachClient.swift
@@ -12,10 +12,6 @@ import Foundation
 /// In the case of this framework, the Mach service is expected to be represented by an `XPCMachServer`.
 internal class XPCMachClient: XPCClient {
     /// Creates and returns a connection for the Mach service represented by this client.
-    ///
-    /// > Note: This client implementation intentionally does not store a reference to the ``xpc_connection_t`` as it can become
-    /// invalid for numerous reasons. Since it's expected relatively few messages will be sent and the lowest possible
-    /// latency isn't needed, it's simpler to always create the connection on demand each time a message is to be sent.
     internal override func createConnection() -> xpc_connection_t {
         xpc_connection_create_mach_service(self.serviceName, nil, 0)
     }

--- a/Sources/SecureXPC/Client/XPCMachClient.swift
+++ b/Sources/SecureXPC/Client/XPCMachClient.swift
@@ -11,20 +11,12 @@ import Foundation
 ///
 /// In the case of this framework, the Mach service is expected to be represented by an `XPCMachServer`.
 internal class XPCMachClient: XPCClient {
-    
-	/// Creates and returns a connection for the Mach service represented by this client.
-	/// 
-	/// > Note: This client implementation intentionally does not store a reference to the ``xpc_connection_t`` as it can become
-	/// invalid for numerous reasons. Since it's expected relatively few messages will be sent and the lowest possible
-	/// latency isn't needed, it's simpler to always create the connection on demand each time a message is to be sent.
-	internal override func createConnection() -> xpc_connection_t {
-		let connection = xpc_connection_create_mach_service(self.serviceName, nil, 0)
-		xpc_connection_set_event_handler(connection, { (event: xpc_object_t) in
-			// A block *must* be set as the handler, even though this block does nothing.
-			// If it were not set, a crash would occur upon calling xpc_connection_resume.
-		})
-		xpc_connection_resume(connection)
-
-		return connection
-	}
+    /// Creates and returns a connection for the Mach service represented by this client.
+    ///
+    /// > Note: This client implementation intentionally does not store a reference to the ``xpc_connection_t`` as it can become
+    /// invalid for numerous reasons. Since it's expected relatively few messages will be sent and the lowest possible
+    /// latency isn't needed, it's simpler to always create the connection on demand each time a message is to be sent.
+    internal override func createConnection() -> xpc_connection_t {
+        xpc_connection_create_mach_service(self.serviceName, nil, 0)
+    }
 }

--- a/Sources/SecureXPC/Client/XPCServiceClient.swift
+++ b/Sources/SecureXPC/Client/XPCServiceClient.swift
@@ -12,10 +12,6 @@ import Foundation
 /// In the case of this framework, the XPC Service is expected to be represented by an `XPCServiceServer`.
 internal class XPCServiceClient: XPCClient {
     /// Creates and returns a connection for the XPC service represented by this client.
-    ///
-    /// > Note: This client implementation intentionally does not store a reference to the ``xpc_connection_t`` as it can become
-    /// invalid for numerous reasons. Since it's expected relatively few messages will be sent and the lowest possible
-    /// latency isn't needed, it's simpler to always create the connection on demand each time a message is to be sent.
     internal override func createConnection() -> xpc_connection_t {
         xpc_connection_create(self.serviceName, nil)
     }

--- a/Sources/SecureXPC/Client/XPCServiceClient.swift
+++ b/Sources/SecureXPC/Client/XPCServiceClient.swift
@@ -11,20 +11,12 @@ import Foundation
 ///
 /// In the case of this framework, the XPC Service is expected to be represented by an `XPCServiceServer`.
 internal class XPCServiceClient: XPCClient {
-    
-	/// Creates and returns a connection for the XPC service represented by this client.
-	///
-	/// > Note: This client implementation intentionally does not store a reference to the ``xpc_connection_t`` as it can become
-	/// invalid for numerous reasons. Since it's expected relatively few messages will be sent and the lowest possible
-	/// latency isn't needed, it's simpler to always create the connection on demand each time a message is to be sent.
-	internal override func createConnection() -> xpc_connection_t {
-		let connection = xpc_connection_create(self.serviceName, nil)
-		xpc_connection_set_event_handler(connection, { (event: xpc_object_t) in
-			// A block *must* be set as the handler, even though this block does nothing.
-			// If it were not set, a crash would occur upon calling xpc_connection_resume.
-		})
-		xpc_connection_resume(connection)
-
-		return connection
-	}
+    /// Creates and returns a connection for the XPC service represented by this client.
+    ///
+    /// > Note: This client implementation intentionally does not store a reference to the ``xpc_connection_t`` as it can become
+    /// invalid for numerous reasons. Since it's expected relatively few messages will be sent and the lowest possible
+    /// latency isn't needed, it's simpler to always create the connection on demand each time a message is to be sent.
+    internal override func createConnection() -> xpc_connection_t {
+        xpc_connection_create(self.serviceName, nil)
+    }
 }


### PR DESCRIPTION
I think it's time to add the ability to persist client connections. This unlocks several capabilities:

1. Passing a connection between processes (`xpc_endpoint_t`) requires that you create an endpoint from a connection, and *not* merely a service name.
2. This hugely reduces the latency of subsequent messages sent to the same connection (which is crucial for my use case, where I'm sending several messages a second, and the connection setup time is well over a second)
3. Adding support for `xpc_endpoint_t` (coming soon™) will mean that anonymous connections will be possible. I can use this to [write an integration test](https://developer.apple.com/forums/thread/693955) that does a full test of the client messaging/sending code

This code might seem familiar, and that's because this commit used to be a part of #18. It can ship on its own here without any of the other error-handling (I'm still working on that)