### PR TITLE
Add Endpoint APIs

### DIFF
--- a/Sources/SecureXPC/Client/XPCClient.swift
+++ b/Sources/SecureXPC/Client/XPCClient.swift
@@ -106,7 +106,7 @@ public class XPCClient {
     ///   - named: The bundle identifier of the XPC Service.
     /// - Returns: A client configured to communicate with the named service.
     public static func forXPCService(named xpcServiceName: String) -> XPCClient {
-        XPCServiceClient(serviceName: xpcServiceName)
+        XPCServiceClient(xpcServiceName: xpcServiceName)
     }
     
     /// Provides a client to communicate with an XPC Mach service.
@@ -123,20 +123,18 @@ public class XPCClient {
     ///    - named: A key in the `MachServices` entry of the tool's launchd property list.
     /// - Returns: A client configured to communicate with the named service.
     public static func forMachService(named machServiceName: String) -> XPCClient {
-        XPCMachClient(serviceName: machServiceName)
+        XPCMachClient(machServiceName: machServiceName)
     }
 
     // MARK: Implementation
 
-    internal let serviceName: String
     private var connection: xpc_connection_t? = nil
     
     /// Creates a client which will attempt to send messages to the specified mach service.
     ///
     /// - Parameters:
     ///   - serviceName: The name of the XPC service; no validation is performed on this.
-    internal init(serviceName: String) {
-        self.serviceName = serviceName
+    internal init() {
     }
     
     /// Receives the result of an XPC send. The result is either an instance of the reply type on success or an ``XPCError`` on failure.
@@ -248,6 +246,11 @@ public class XPCClient {
     }
 
     // MARK: Abstract methods
+
+
+    public var serviceName: String? {
+        fatalError("Abstract Property")
+    }
 
     /// Creates and returns a connection for the service represented by this client.
     internal func createConnection() -> xpc_connection_t {

--- a/Sources/SecureXPC/Client/XPCMachClient.swift
+++ b/Sources/SecureXPC/Client/XPCMachClient.swift
@@ -11,8 +11,16 @@ import Foundation
 ///
 /// In the case of this framework, the Mach service is expected to be represented by an `XPCMachServer`.
 internal class XPCMachClient: XPCClient {
+    private let machServiceName: String
+
+    override var serviceName: String? { machServiceName }
+
+    internal init(machServiceName: String) {
+        self.machServiceName = machServiceName
+    }
+
     /// Creates and returns a connection for the Mach service represented by this client.
     internal override func createConnection() -> xpc_connection_t {
-        xpc_connection_create_mach_service(self.serviceName, nil, 0)
+        xpc_connection_create_mach_service(self.machServiceName, nil, 0)
     }
 }

--- a/Sources/SecureXPC/Client/XPCMachClient.swift
+++ b/Sources/SecureXPC/Client/XPCMachClient.swift
@@ -15,8 +15,9 @@ internal class XPCMachClient: XPCClient {
 
     override var serviceName: String? { machServiceName }
 
-    internal init(machServiceName: String) {
+    internal init(machServiceName: String, connection: xpc_connection_t? = nil) {
         self.machServiceName = machServiceName
+        super.init(connection: connection)
     }
 
     /// Creates and returns a connection for the Mach service represented by this client.

--- a/Sources/SecureXPC/Client/XPCServiceClient.swift
+++ b/Sources/SecureXPC/Client/XPCServiceClient.swift
@@ -15,8 +15,9 @@ internal class XPCServiceClient: XPCClient {
 
     override var serviceName: String? { xpcServiceName }
 
-    internal init(xpcServiceName: String) {
+    internal init(xpcServiceName: String, connection: xpc_connection_t? = nil) {
         self.xpcServiceName = xpcServiceName
+        super.init(connection: connection)
     }
     
     /// Creates and returns a connection for the XPC service represented by this client.

--- a/Sources/SecureXPC/Client/XPCServiceClient.swift
+++ b/Sources/SecureXPC/Client/XPCServiceClient.swift
@@ -11,6 +11,14 @@ import Foundation
 ///
 /// In the case of this framework, the XPC Service is expected to be represented by an `XPCServiceServer`.
 internal class XPCServiceClient: XPCClient {
+    private let xpcServiceName: String
+
+    override var serviceName: String? { xpcServiceName }
+
+    internal init(xpcServiceName: String) {
+        self.xpcServiceName = xpcServiceName
+    }
+    
     /// Creates and returns a connection for the XPC service represented by this client.
     internal override func createConnection() -> xpc_connection_t {
         xpc_connection_create(self.serviceName, nil)

--- a/Sources/SecureXPC/Server/XPCMachServer.swift
+++ b/Sources/SecureXPC/Server/XPCMachServer.swift
@@ -201,6 +201,12 @@ internal class XPCMachServer: XPCServer, NonBlockingStartable {
 	}
 
     public override var endpoint: XPCServerEndpoint {
+        fatalError("""
+            The ability to export the endpoint of an XPCServer for a Mach Service is untested, and likely broken.
+
+            See https://github.com/trilemma-dev/SecureXPC/issues/33
+        """)
+
         guard let connection = self.serviceListenerConnection else {
             fatalError("An XPCServer's endpoint can only be retrieved after start() has been called on it.")
         }

--- a/Sources/SecureXPC/Server/XPCMachServer.swift
+++ b/Sources/SecureXPC/Server/XPCMachServer.swift
@@ -14,7 +14,8 @@ internal class XPCMachServer: XPCServer, NonBlockingStartable {
     
     private let machServiceName: String
     private let clientRequirements: [SecRequirement]
-    
+    private var serviceListenerConnection: xpc_connection_t? = nil
+
     /// This should only ever be called from `getXPCMachServer(...)` so that client requirement invariants are upheld.
     private init(machServiceName: String, clientRequirements: [SecRequirement]) {
         self.machServiceName = machServiceName
@@ -152,16 +153,18 @@ internal class XPCMachServer: XPCServer, NonBlockingStartable {
                 nil, // targetq: DispatchQueue, defaults to using DISPATCH_TARGET_QUEUE_DEFAULT
                 UInt64(XPC_CONNECTION_MACH_SERVICE_LISTENER))
         }
-        
+
+        self.serviceListenerConnection = machService
+
         // Start listener for the Mach service, all received events should be for incoming connections
-         xpc_connection_set_event_handler(machService, { connection in
-             // Listen for events (messages or errors) coming from this connection
-             xpc_connection_set_event_handler(connection, { event in
-                 self.handleEvent(connection: connection, event: event)
-             })
-             xpc_connection_resume(connection)
-         })
-         xpc_connection_resume(machService)
+        xpc_connection_set_event_handler(machService, { connection in
+            // Listen for events (messages or errors) coming from this connection
+            xpc_connection_set_event_handler(connection, { event in
+                self.handleEvent(connection: connection, event: event)
+            })
+            xpc_connection_resume(connection)
+        })
+        xpc_connection_resume(machService)
     }
     
 	public override func startAndBlock() -> Never {
@@ -196,6 +199,18 @@ internal class XPCMachServer: XPCServer, NonBlockingStartable {
 
 		return accept
 	}
+
+    public override var endpoint: XPCServerEndpoint {
+        guard let connection = self.serviceListenerConnection else {
+            fatalError("An XPCServer's endpoint can only be retrieved after start() has been called on it.")
+        }
+
+        let endpoint = xpc_endpoint_create(connection)
+        return XPCServerEndpoint(
+            serviceDescriptor: .machService(name: self.machServiceName),
+            endpoint: endpoint
+        )
+    }
 
 	/// Wrapper around the private undocumented function `void xpc_connection_get_audit_token(xpc_connection_t, audit_token_t *)`.
 	///

--- a/Sources/SecureXPC/Server/XPCServer.swift
+++ b/Sources/SecureXPC/Server/XPCServer.swift
@@ -314,6 +314,14 @@ public class XPCServer {
 	internal func acceptMessage(connection: xpc_connection_t, message: xpc_object_t) -> Bool {
 		fatalError("Abstract Method")
 	}
+
+    public var serviceName: String? {
+        fatalError("Abstract Property")
+    }
+
+    public var endpoint: XPCServerEndpoint {
+        fatalError("Abstract Method")
+    }
 }
 
 // MARK: public server protocols

--- a/Sources/SecureXPC/Server/XPCServiceServer.swift
+++ b/Sources/SecureXPC/Server/XPCServiceServer.swift
@@ -11,14 +11,18 @@ import Foundation
 ///
 /// In the case of this framework, the XPC Service is expected to be communicated with by an `XPCServiceClient`.
 internal class XPCServiceServer: XPCServer {
-    
 	private static let service = XPCServiceServer()
+    private var connection: xpc_connection_t? = nil
 
     internal static func _forThisXPCService() throws -> XPCServiceServer {
         // An XPC Service's package type must be equal to "XPC!", see Apple's documentation for details
         // https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/CreatingXPCServices.html#//apple_ref/doc/uid/10000172i-SW6-SW6
         if mainBundlePackageInfo().packageType != "XPC!" {
             throw XPCError.notXPCService
+        }
+
+        if Bundle.main.bundleIdentifier == nil {
+            throw XPCError.misconfiguredXPCService
         }
         
         return service
@@ -40,9 +44,16 @@ internal class XPCServiceServer: XPCServer {
 
         return (uint32ToString(packageType.bigEndian), uint32ToString(packageCreator.bigEndian))
     }
-    
+
+    // This is safe to unwrap because it was already checked in ``_forThisXPCService``.
+    private lazy var xpcServiceName: String = Bundle.main.bundleIdentifier!
+
 	public override func startAndBlock() -> Never {
 		xpc_main { connection in
+            // This is an @convention(c) closure, so we can't just capture `self`.
+            // We access the connection via the singleton reference, instead.
+            XPCServiceServer.service.connection = connection
+
 			// Listen for events (messages or errors) coming from this connection
 			xpc_connection_set_event_handler(connection, { event in
 				XPCServiceServer.service.handleEvent(connection: connection, event: event)
@@ -55,4 +66,20 @@ internal class XPCServiceServer: XPCServer {
 		// XPC services are application-scoped, so we're assuming they're inheritently safe
 		true
 	}
+
+    public override var serviceName: String? {
+        xpcServiceName
+    }
+
+    public override var endpoint: XPCServerEndpoint {
+        guard let connection = self.connection else {
+            fatalError("An XPCServer's endpoint can only be retrieved after startAndBlock() has been called on it.")
+        }
+
+        let endpoint = xpc_endpoint_create(connection)
+        return XPCServerEndpoint(
+            serviceDescriptor: .xpcService(name: self.xpcServiceName),
+            endpoint: endpoint
+        )
+    }
 }

--- a/Sources/SecureXPC/XPCError.swift
+++ b/Sources/SecureXPC/XPCError.swift
@@ -56,6 +56,10 @@ public enum XPCError: Error, Codable {
     /// This may mean there is a configuration issue. Alternatively it could be the caller is an XPC Mach service, in which case use
     /// ``XPCServer/forThisMachService(named:clientRequirements:)`` instead.
     case notXPCService
+    /// The caller is a misconfigured XPC Service.
+    ///
+    /// Currently, this means that its bundle idenifiter was not set.
+    case misconfiguredXPCService
     /// An error occurred that is not part of this framework, for example an error thrown by a handler registered with a ``XPCServer`` route. The associated
     /// value describes the error.
     case other(String)

--- a/Sources/SecureXPC/XPCServerEndpoint.swift
+++ b/Sources/SecureXPC/XPCServerEndpoint.swift
@@ -1,0 +1,21 @@
+//
+//  XPCServerEndpoint.swift
+//  
+//
+//  Created by Alexander Momchilov on 2021-11-28.
+//
+
+import Foundation
+
+// TODO: make this codable so it can be sent over XPC.
+public struct XPCServerEndpoint {
+    // Technically, an `xpc_endpoint_t` is sufficient to create a new connection, on its own. However, it's useful to
+    // be able to communicate the kind of connection, and its name, so we also store those, separately.
+    internal let serviceDescriptor: XPCServiceDescriptor
+    internal let endpoint: xpc_endpoint_t
+
+    internal init(serviceDescriptor: XPCServiceDescriptor, endpoint: xpc_endpoint_t) {
+        self.serviceDescriptor = serviceDescriptor
+        self.endpoint = endpoint
+    }
+}

--- a/Sources/SecureXPC/XPCServiceDescriptor.swift
+++ b/Sources/SecureXPC/XPCServiceDescriptor.swift
@@ -1,0 +1,13 @@
+//
+//  XPCServiceDescriptor.swift
+//  
+//
+//  Created by Alexander Momchilov on 2021-11-28.
+//
+
+import Foundation
+
+internal enum XPCServiceDescriptor {
+    case xpcService(name: String)
+    case machService(name: String)
+}


### PR DESCRIPTION
This PR builds on top of the code introduced in #21. Do not ship until #21 is merged.

Add a new `XPCEndpoint` wrapper around `xpc_endpoint_t`.