### PR TITLE
Add support for anonymous connections

### DIFF
--- a/Sources/SecureXPC/Client/XPCAnonymousServiceClient.swift
+++ b/Sources/SecureXPC/Client/XPCAnonymousServiceClient.swift
@@ -1,0 +1,25 @@
+//
+//  XPCAnonymousServiceClient.swift
+//  SecureXPC
+//
+//  Created by Alexander Momchilov on 2021-12-04
+//
+
+import Foundation
+
+/// A concrete implementation of ``XPCClient`` which can communicate with an anonymous XPC service.
+///
+/// In the case of this framework, the Mach service is expected to be represented by an `XPCMachServer`.
+internal class XPCAnonymousServiceClient: XPCClient {
+    override var serviceName: String? { nil }
+
+    // Anonymous service clients *must* be created from an existing connection.
+    init(connection: xpc_connection_t) {
+        super.init(connection: connection)
+    }
+
+    /// Creates and returns a connection for the Mach service represented by this client.
+    internal override func createConnection() -> xpc_connection_t {
+        fatalError("Anonymous XPC connections cannot be restarted.")
+    }
+}

--- a/Sources/SecureXPC/Client/XPCClient.swift
+++ b/Sources/SecureXPC/Client/XPCClient.swift
@@ -135,6 +135,7 @@ public class XPCClient {
         xpc_connection_resume(connection)
 
         switch endpoint.serviceDescriptor {
+        case .anonymous: return XPCAnonymousServiceClient(connection: connection)
         case .xpcService(name: let name): return XPCServiceClient(xpcServiceName: name, connection: connection)
         case .machService(name: let name): return XPCMachClient(machServiceName: name, connection: connection)
         }

--- a/Sources/SecureXPC/Server/XPCAnonymousServer.swift
+++ b/Sources/SecureXPC/Server/XPCAnonymousServer.swift
@@ -26,6 +26,7 @@ internal class XPCAnonymousServer: XPCServer {
 
     internal override func acceptMessage(connection: xpc_connection_t, message: xpc_object_t) -> Bool {
         // Anonymous service connections should only ever passed among trusted parties.
+        // TODO: add support for client security requirements https://github.com/trilemma-dev/SecureXPC/issues/36
         true
     }
 

--- a/Sources/SecureXPC/Server/XPCAnonymousServer.swift
+++ b/Sources/SecureXPC/Server/XPCAnonymousServer.swift
@@ -1,0 +1,49 @@
+//
+//  XPCAnonymousServer.swift
+//  
+//
+//  Created by Alexander Momchilov on 2021-11-28.
+//
+
+import Foundation
+
+internal class XPCAnonymousServer: XPCServer {
+    private let anonymousListenerConnection: xpc_connection_t
+
+    internal override init() {
+        self.anonymousListenerConnection = xpc_connection_create(nil, nil)
+        super.init()
+
+        // Start listener for the new anonymous connection, all received events should be for incoming client connections
+         xpc_connection_set_event_handler(anonymousListenerConnection, { newClientConnection in
+             // Listen for events (messages or errors) coming from this connection
+             xpc_connection_set_event_handler(newClientConnection, { event in
+                 self.handleEvent(connection: newClientConnection, event: event)
+             })
+             xpc_connection_resume(newClientConnection)
+         })
+    }
+
+    internal override func acceptMessage(connection: xpc_connection_t, message: xpc_object_t) -> Bool {
+        // Anonymous service connections should only ever passed among trusted parties.
+        true
+    }
+
+    /// Begins processing requests received by this XPC server and never returns.
+    public override func startAndBlock() -> Never {
+        fatalError("startAndBlock() is not supported for anonymous connections. Use start() instead.")
+    }
+
+    public override var endpoint: XPCServerEndpoint {
+        XPCServerEndpoint(
+            serviceDescriptor: .anonymous,
+            endpoint: xpc_endpoint_create(self.anonymousListenerConnection)
+        )
+    }
+}
+
+extension XPCAnonymousServer: NonBlockingStartable {
+    public func start() {
+        xpc_connection_resume(self.anonymousListenerConnection)
+    }
+}

--- a/Sources/SecureXPC/Server/XPCServer.swift
+++ b/Sources/SecureXPC/Server/XPCServer.swift
@@ -111,6 +111,10 @@ public class XPCServer {
     public static func forThisXPCService() throws -> XPCServer {
         try XPCServiceServer._forThisXPCService()
     }
+
+    public static func makeAnonymousService() -> XPCServer & NonBlockingStartable {
+        XPCAnonymousServer()
+    }
     
     /// Provides a server for this helper tool if it was installed with
     /// [`SMJobBless`](https://developer.apple.com/documentation/servicemanagement/1431078-smjobbless).

--- a/Sources/SecureXPC/Server/XPCServer.swift
+++ b/Sources/SecureXPC/Server/XPCServer.swift
@@ -112,7 +112,7 @@ public class XPCServer {
         try XPCServiceServer._forThisXPCService()
     }
 
-    public static func makeAnonymousService() -> XPCServer & NonBlockingStartable {
+    internal static func makeAnonymousService() -> XPCServer & NonBlockingStartable {
         XPCAnonymousServer()
     }
     

--- a/Sources/SecureXPC/XPCServiceDescriptor.swift
+++ b/Sources/SecureXPC/XPCServiceDescriptor.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 internal enum XPCServiceDescriptor {
+    case anonymous
     case xpcService(name: String)
     case machService(name: String)
 }


### PR DESCRIPTION
This PR builds on top of the code introduced in #23. Do not ship until #23 is merged.

Adds a new `XPCAnonymousServer` that can be passed around using an `XPCEndpoint`. `XPCEndpoint` can then be used to create a client that connects to the anonymous service.