### PR TITLE
`XPCServer` now supports specifying a target queue

### DIFF
--- a/Sources/SecureXPC/Server/XPCMachServer.swift
+++ b/Sources/SecureXPC/Server/XPCMachServer.swift
@@ -163,7 +163,7 @@ internal class XPCMachServer: XPCServer, NonBlockingStartable {
              xpc_connection_set_event_handler(connection, { event in
                  self.handleEvent(connection: connection, event: event)
              })
-             self.connections.append(Weak<xpc_connection_t>(connection))
+             self.addConnection(connection)
              xpc_connection_resume(connection)
          })
          xpc_connection_resume(listenerConnection)

--- a/Sources/SecureXPC/Server/XPCMachServer.swift
+++ b/Sources/SecureXPC/Server/XPCMachServer.swift
@@ -163,7 +163,7 @@ internal class XPCMachServer: XPCServer, NonBlockingStartable {
              xpc_connection_set_event_handler(connection, { event in
                  self.handleEvent(connection: connection, event: event)
              })
-             self.connections.append(WeakConnection(connection))
+             self.connections.append(Weak<xpc_connection_t>(connection))
              xpc_connection_resume(connection)
          })
          xpc_connection_resume(listenerConnection)

--- a/Sources/SecureXPC/Server/XPCMachServer.swift
+++ b/Sources/SecureXPC/Server/XPCMachServer.swift
@@ -159,14 +159,14 @@ internal class XPCMachServer: XPCServer, NonBlockingStartable {
         self.listenerConnection = listenerConnection
       
         // Start listener for the Mach service, all received events should be for incoming connections
-        xpc_connection_set_event_handler(machService, { connection in
+        xpc_connection_set_event_handler(listenerConnection, { connection in
             // Listen for events (messages or errors) coming from this connection
             xpc_connection_set_event_handler(connection, { event in
                 self.handleEvent(connection: connection, event: event)
             })
             xpc_connection_resume(connection)
         })
-        xpc_connection_resume(machService)
+        xpc_connection_resume(listenerConnection)
     }
     
 	public override func startAndBlock() -> Never {
@@ -209,7 +209,7 @@ internal class XPCMachServer: XPCServer, NonBlockingStartable {
             See https://github.com/trilemma-dev/SecureXPC/issues/33
         """)
 
-        guard let connection = self.serviceListenerConnection else {
+        guard let connection = self.listenerConnection else {
             fatalError("An XPCServer's endpoint can only be retrieved after start() has been called on it.")
         }
 

--- a/Sources/SecureXPC/Server/XPCServer.swift
+++ b/Sources/SecureXPC/Server/XPCServer.swift
@@ -285,10 +285,12 @@ public class XPCServer {
         // The finalizer is called when the connection's retain count has reached zero, so now we need to remove the
         // wrapper from the containing connections array
         xpc_connection_set_finalizer_f(connection, { opaqueWeakConnection in
-            if let opaqueWeakConnection = opaqueWeakConnection {
-                let weakConnection = Unmanaged<WeakConnection>.fromOpaque(opaqueWeakConnection).takeUnretainedValue()
-                weakConnection.removeFromContainer()
+            guard let opaqueWeakConnection = opaqueWeakConnection else {
+                fatalError("Connection with retain count of zero is missing context, this should never happen")
             }
+            
+            let weakConnection = Unmanaged<WeakConnection>.fromOpaque(opaqueWeakConnection).takeUnretainedValue()
+            weakConnection.removeFromContainer()
         })
     }
     

--- a/Sources/SecureXPC/Server/XPCServer.swift
+++ b/Sources/SecureXPC/Server/XPCServer.swift
@@ -199,7 +199,13 @@ public class XPCServer {
         }
         
         static func == (lhs: XPCServer.WeakConnection, rhs: XPCServer.WeakConnection) -> Bool {
-            lhs.connectionHash == rhs.connectionHash
+            if let lconnection = lhs.connection, let rconnection = rhs.connection { // Compare connections directly
+                return xpc_equal(lconnection, rconnection)
+            } else if lhs.connection == nil && rhs.connection == nil { // Compare hashes as connections no longer exist
+                return lhs.connectionHash == rhs.connectionHash
+            } else { // Only one has a connection, so never equal
+                return false
+            }
         }
         
         func hash(into hasher: inout Hasher) {

--- a/Sources/SecureXPC/Server/XPCServer.swift
+++ b/Sources/SecureXPC/Server/XPCServer.swift
@@ -186,11 +186,10 @@ public class XPCServer {
     fileprivate class WeakConnection: Hashable {
         private weak var server: XPCServer?
         fileprivate weak var connection: xpc_connection_t?
-        private let connectionHash: Int
+        private let id = UUID()
         
         init(_ connection: xpc_connection_t, server: XPCServer) {
             self.connection = connection
-            self.connectionHash = xpc_hash(connection)
             self.server = server
         }
         
@@ -199,17 +198,11 @@ public class XPCServer {
         }
         
         static func == (lhs: XPCServer.WeakConnection, rhs: XPCServer.WeakConnection) -> Bool {
-            if let lconnection = lhs.connection, let rconnection = rhs.connection { // Compare connections directly
-                return xpc_equal(lconnection, rconnection)
-            } else if lhs.connection == nil && rhs.connection == nil { // Compare hashes as connections no longer exist
-                return lhs.connectionHash == rhs.connectionHash
-            } else { // Only one has a connection, so never equal
-                return false
-            }
+            lhs.id == rhs.id
         }
         
         func hash(into hasher: inout Hasher) {
-            hasher.combine(self.connectionHash)
+            self.id.hash(into: &hasher)
         }
     }
     

--- a/Sources/SecureXPC/Server/XPCServer.swift
+++ b/Sources/SecureXPC/Server/XPCServer.swift
@@ -177,8 +177,35 @@ public class XPCServer {
     // Routes
     private var routes = [XPCRoute : XPCHandler]()
     
-    /// Array of weak references to connections, used to update their dispatch queues
-    internal var connections = [Weak<xpc_connection_t>]()
+    /// Set of weak references to connections, used to update their dispatch queues.
+    private var connections = Set<WeakConnection>()
+    
+    /// Weak wrapper around a connection stored in the `connections` variable.
+    ///
+    /// Designed to be conveniently settable as the context of an `xpc_connection_t` so that it's accessible from its finalizer.
+    fileprivate class WeakConnection: Hashable {
+        private weak var server: XPCServer?
+        fileprivate weak var connection: xpc_connection_t?
+        private let connectionHash: Int
+        
+        init(_ connection: xpc_connection_t, server: XPCServer) {
+            self.connection = connection
+            self.connectionHash = xpc_hash(connection)
+            self.server = server
+        }
+        
+        func removeFromContainer() {
+            self.server?.connections.remove(self)
+        }
+        
+        static func == (lhs: XPCServer.WeakConnection, rhs: XPCServer.WeakConnection) -> Bool {
+            lhs.connectionHash == rhs.connectionHash
+        }
+        
+        func hash(into hasher: inout Hasher) {
+            hasher.combine(self.connectionHash)
+        }
+    }
     
     /// The queue used to run the handlers associated with registered routes.
     ///
@@ -186,7 +213,7 @@ public class XPCServer {
     /// returned from reading this property will always be the one most recently set even if it is not yet the queue used to run handlers for all incoming requests.
     public var targetQueue: DispatchQueue? {
         willSet {
-            connections.compactMap{ $0.value }.forEach{ xpc_connection_set_target_queue($0, newValue) }
+            connections.compactMap{ $0.connection }.forEach{ xpc_connection_set_target_queue($0, newValue) }
         }
     }
     
@@ -250,6 +277,22 @@ public class XPCServer {
         self.routes[route.route] = ConstrainedXPCHandlerWithMessageWithReply(handler: handler)
     }
     
+    internal func addConnection(_ connection: xpc_connection_t) {
+        // Keep a weak reference to the connection and this server, setting this as the context on the connection
+        let weakConnection = WeakConnection(connection, server: self)
+        self.connections.insert(weakConnection)
+        xpc_connection_set_context(connection, Unmanaged.passUnretained(weakConnection).toOpaque())
+        
+        // The finalizer is called when the connection's retain count has reached zero, so now we need to remove the
+        // wrapper from the containing connections array
+        xpc_connection_set_finalizer_f(connection, { opaqueWeakConnection in
+            if let opaqueWeakConnection = opaqueWeakConnection {
+                let weakConnection = Unmanaged<WeakConnection>.fromOpaque(opaqueWeakConnection).takeUnretainedValue()
+                weakConnection.removeFromContainer()
+            }
+        })
+    }
+    
     internal func handleEvent(connection: xpc_connection_t, event: xpc_object_t) {
         if xpc_get_type(event) == XPC_TYPE_DICTIONARY {
             if self.acceptMessage(connection: connection, message: event) {
@@ -276,9 +319,6 @@ public class XPCServer {
                 self.errorHandler?(XPCError.insecure)
             }
         } else if xpc_equal(event, XPC_ERROR_CONNECTION_INVALID) {
-            // Removes this connection as it's become invalid as well as any other weak connections which now happen to
-            // be wrapping a nil connection
-            self.connections.removeAll { $0.value == nil ? true : xpc_equal($0.value!, connection) }
             self.errorHandler?(XPCError.connectionInvalid)
         } else if xpc_equal(event, XPC_ERROR_CONNECTION_INTERRUPTED) {
             self.errorHandler?(XPCError.connectionInterrupted)

--- a/Sources/SecureXPC/Server/XPCServiceServer.swift
+++ b/Sources/SecureXPC/Server/XPCServiceServer.swift
@@ -43,10 +43,12 @@ internal class XPCServiceServer: XPCServer {
     
 	public override func startAndBlock() -> Never {
 		xpc_main { connection in
+            xpc_connection_set_target_queue(connection, XPCServiceServer.service.targetQueue)
 			// Listen for events (messages or errors) coming from this connection
 			xpc_connection_set_event_handler(connection, { event in
 				XPCServiceServer.service.handleEvent(connection: connection, event: event)
 			})
+            XPCServiceServer.service.connections.append(WeakConnection(connection))
 			xpc_connection_resume(connection)
 		}
 	}

--- a/Sources/SecureXPC/Server/XPCServiceServer.swift
+++ b/Sources/SecureXPC/Server/XPCServiceServer.swift
@@ -48,7 +48,7 @@ internal class XPCServiceServer: XPCServer {
 			xpc_connection_set_event_handler(connection, { event in
 				XPCServiceServer.service.handleEvent(connection: connection, event: event)
 			})
-            XPCServiceServer.service.connections.append(WeakConnection(connection))
+            XPCServiceServer.service.connections.append(Weak<xpc_connection_t>(connection))
 			xpc_connection_resume(connection)
 		}
 	}

--- a/Sources/SecureXPC/Server/XPCServiceServer.swift
+++ b/Sources/SecureXPC/Server/XPCServiceServer.swift
@@ -48,7 +48,7 @@ internal class XPCServiceServer: XPCServer {
 			xpc_connection_set_event_handler(connection, { event in
 				XPCServiceServer.service.handleEvent(connection: connection, event: event)
 			})
-            XPCServiceServer.service.connections.append(Weak<xpc_connection_t>(connection))
+            XPCServiceServer.service.addConnection(connection)
 			xpc_connection_resume(connection)
 		}
 	}

--- a/Sources/SecureXPC/XPCCommon.swift
+++ b/Sources/SecureXPC/XPCCommon.swift
@@ -19,12 +19,3 @@ func const(_ input: UnsafePointer<CChar>!) -> UnsafePointer<CChar>! {
 	let mutableCopy = strdup(input)!
 	return UnsafePointer(mutableCopy) // The result should never actually be mutated
 }
-
-/// Weak reference wrapper
-internal class Weak<T: AnyObject> {
-    weak var value: T?
-    
-    init(_ value: T) {
-        self.value = value
-    }
-}

--- a/Sources/SecureXPC/XPCCommon.swift
+++ b/Sources/SecureXPC/XPCCommon.swift
@@ -19,3 +19,12 @@ func const(_ input: UnsafePointer<CChar>!) -> UnsafePointer<CChar>! {
 	let mutableCopy = strdup(input)!
 	return UnsafePointer(mutableCopy) // The result should never actually be mutated
 }
+
+/// Weak reference wrapper
+internal class Weak<T: AnyObject> {
+    weak var value: T?
+    
+    init(_ value: T) {
+        self.value = value
+    }
+}


### PR DESCRIPTION
In order to support this, the server now holds an array of weak references to all of the connections that it has received