### PR TITLE
Load `xpc_connection_get_audit_token` only once

### DIFF
--- a/Sources/SecureXPC/Server/SecureMessageAcceptor.swift
+++ b/Sources/SecureXPC/Server/SecureMessageAcceptor.swift
@@ -23,9 +23,11 @@ internal struct SecureMessageAcceptor {
         if #available(macOS 11, *) { // publicly documented, but only available since macOS 11
             SecCodeCreateWithXPCMessage(message, SecCSFlags(), &code)
         } else { // private undocumented function: xpc_connection_get_audit_token, available on prior versions of macOS
-            var auditToken = SecureMessageAcceptor.xpc_connection_get_audit_token(connection)
-            let tokenData = NSData(bytes: &auditToken, length: MemoryLayout.size(ofValue: auditToken))
-            let attributes = [kSecGuestAttributeAudit : tokenData] as NSDictionary
+            let token = SecureMessageAcceptor.xpc_connection_get_audit_token(connection)
+            let tokenValues = [token.val.0, token.val.1, token.val.2, token.val.3,
+                               token.val.4, token.val.5, token.val.6, token.val.7]
+            let tokenData = Data(bytes: tokenValues, count: tokenValues.count * MemoryLayout<UInt32>.size)
+            let attributes = [kSecGuestAttributeAudit : tokenData] as CFDictionary
             SecCodeCopyGuestWithAttributes(nil, attributes, SecCSFlags(), &code)
         }
         guard let code = code else { // Instead of explitly checking the return codes from the SecCode* function calls

--- a/Sources/SecureXPC/Server/SecureMessageAcceptor.swift
+++ b/Sources/SecureXPC/Server/SecureMessageAcceptor.swift
@@ -14,53 +14,64 @@ internal struct SecureMessageAcceptor {
     /// At least one of these code signing requirements must be met in order for the message to be accepted
     internal let requirements: [SecRequirement]
     
+    /// Accepts a message if it meets at least on of the provided `requirements`.
+    ///
+    /// If the `SecCode` of the process belonging to the other side of the connection could be not be determined, `false` is always returned.
     func acceptMessage(connection: xpc_connection_t, message: xpc_object_t) -> Bool {
         // Get the code representing the client
         var code: SecCode?
         if #available(macOS 11, *) { // publicly documented, but only available since macOS 11
             SecCodeCreateWithXPCMessage(message, SecCSFlags(), &code)
         } else { // private undocumented function: xpc_connection_get_audit_token, available on prior versions of macOS
-            guard var auditToken = xpc_connection_get_audit_token(connection) else {
-                return false
-            }
-            
+            var auditToken = SecureMessageAcceptor.xpc_connection_get_audit_token(connection)
             let tokenData = NSData(bytes: &auditToken, length: MemoryLayout.size(ofValue: auditToken))
             let attributes = [kSecGuestAttributeAudit : tokenData] as NSDictionary
             SecCodeCopyGuestWithAttributes(nil, attributes, SecCSFlags(), &code)
         }
-
-        // Accept message if code is valid and meets any of the client requirements
-        guard let code = code else {
+        guard let code = code else { // Instead of explitly checking the return codes from the SecCode* function calls
             return false
         }
         
+        // Accept message if code is valid and meets any of the client requirements
         return self.requirements.contains { SecCodeCheckValidity(code, SecCSFlags(), $0) == errSecSuccess }
     }
     
-    /// Wrapper around the private undocumented function `void xpc_connection_get_audit_token(xpc_connection_t, audit_token_t *)`.
+    // MARK: xpc_connection_get_audit_token
+    
+    /// The function signature of  `void xpc_connection_get_audit_token(xpc_connection_t, audit_token_t *)`.
+    private typealias get_audit_token = @convention(c) (xpc_connection_t, UnsafeMutablePointer<audit_token_t>) -> Void
+    
+    /// Represents the private undocumented function `void xpc_connection_get_audit_token(xpc_connection_t, audit_token_t *)`.
+    /// If the function does exist, but does not match the expected signature, then when this variable is loaded the process accessing this variable will crash.
+    /// However, this variable should only be access on older versions of macOS which are expected to have a stable non-changing API so this should not occur.
     ///
-    /// The private undocumented function will attempt to be dynamically loaded and then invoked. If no function exists with this name `nil` will be returned. If
-    /// the function does exist, but does not match the expected signature, the process calling this function is expected to crash. However, because this is only
-    /// called on older versions of macOS which are expected to have a stable non-changing API this is very unlikely to occur.
+    /// If this function can't be loaded for some version, a fatalError will intentonally be raised as this should never occur on an older version of macOS supported by
+    /// SecureXPC.
     ///
-    /// - Parameters:
-    ///   - _:  The connection for which the audit token will be retrieved for.
-    /// - Returns: The audit token or `nil` if the function could not be called.
-    private func xpc_connection_get_audit_token(_ connection: xpc_connection_t) -> audit_token_t? {
-        // Attempt to dynamically load the function
+    /// Note that because static variables are implicitly lazy the code to populate this variable never run unless this variable is accessed.
+    private static var xpc_connection_get_audit_tokenFunction: get_audit_token = {
+        // From man dlopen 3: If a null pointer is passed in path, dlopen() returns a handle equivalent to RTLD_DEFAULT
         guard let handle = dlopen(nil, RTLD_LAZY) else {
-            return nil
+            fatalError("dlopen call to retrieve RTLD_DEFAULT unexpectedly failed, this should never happen")
         }
         defer { dlclose(handle) }
         guard let sym = dlsym(handle, "xpc_connection_get_audit_token") else {
-            return nil
+            // Include macOS version number to assist in reproducing any reported issues
+            fatalError("Function xpc_connection_get_audit_token could not be loaded while running on " +
+                       ProcessInfo.processInfo.operatingSystemVersionString)
         }
-        typealias functionSignature = @convention(c) (xpc_connection_t, UnsafeMutablePointer<audit_token_t>) -> Void
-        let function = unsafeBitCast(sym, to: functionSignature.self)
-
-        // Call the function
+        
+        return unsafeBitCast(sym, to: get_audit_token.self)
+    }()
+    
+    /// Wrapper around the private undocumented function `void xpc_connection_get_audit_token(xpc_connection_t, audit_token_t *)`.
+    ///
+    /// - Parameters:
+    ///   - _:  The connection for which the audit token will be retrieved for.
+    /// - Returns: The audit token.
+    private static func xpc_connection_get_audit_token(_ connection: xpc_connection_t) -> audit_token_t {
         var token = audit_token_t()
-        function(connection, &token)
+        xpc_connection_get_audit_tokenFunction(connection, &token)
         
         return token
     }

--- a/Sources/SecureXPC/Server/SecureMessageAcceptor.swift
+++ b/Sources/SecureXPC/Server/SecureMessageAcceptor.swift
@@ -34,7 +34,6 @@ internal struct SecureMessageAcceptor {
             return false
         }
         
-        // Accept message if code is valid and meets any of the client requirements
         return self.requirements.contains { SecCodeCheckValidity(code, SecCSFlags(), $0) == errSecSuccess }
     }
     


### PR DESCRIPTION
Factors out the loading of `xpc_connection_get_audit_token` so it only happens once per process lifetime

Also changes to the function loading to either succeed or raise a `fatalError` as there's no expectation this will ever fail on the pre-11.0 versions of macOS this code runs on.