### PR TITLE
Throw an error when attempting to reconnect to an anonymous server

### DIFF
--- a/Sources/SecureXPC/Client/XPCAnonymousServiceClient.swift
+++ b/Sources/SecureXPC/Client/XPCAnonymousServiceClient.swift
@@ -9,7 +9,7 @@ import Foundation
 
 /// A concrete implementation of ``XPCClient`` which can communicate with an anonymous XPC service.
 ///
-/// In the case of this framework, the Mach service is expected to be represented by an `XPCMachServer`.
+/// In the case of this framework, the anonymous service is expected to be represented by an `XPCAnonymousServer`.
 internal class XPCAnonymousServiceClient: XPCClient {
     override var serviceName: String? { nil }
 
@@ -17,9 +17,9 @@ internal class XPCAnonymousServiceClient: XPCClient {
     init(connection: xpc_connection_t) {
         super.init(connection: connection)
     }
-
-    /// Creates and returns a connection for the Mach service represented by this client.
-    internal override func createConnection() -> xpc_connection_t {
-        fatalError("Anonymous XPC connections cannot be restarted.")
+    
+    internal override func createConnection() throws -> xpc_connection_t {
+        // Anonymous clients aren't capable of creating a new connection as there is no service to reconnect to
+        throw XPCError.connectionCannotBeReestablished
     }
 }

--- a/Sources/SecureXPC/Client/XPCClient.swift
+++ b/Sources/SecureXPC/Client/XPCClient.swift
@@ -290,7 +290,7 @@ public class XPCClient {
         fatalError("Abstract Property")
     }
 
-    /// Creates and returns a connection for the service represented by this client or throws an error if it's unable to do so.
+    /// Creates and returns a connection for the service represented by this client.
     internal func createConnection() throws -> xpc_connection_t {
         fatalError("Abstract Method")
     }

--- a/Sources/SecureXPC/Server/XPCAnonymousServer.swift
+++ b/Sources/SecureXPC/Server/XPCAnonymousServer.swift
@@ -34,8 +34,7 @@ internal class XPCAnonymousServer: XPCServer {
         )
     }
     
-    // This exists for testing purposes
-    internal func shutdown() {
+    internal func simulateDisconnectionForTesting() {
         xpc_connection_cancel(self.anonymousListenerConnection)
         // A new event handler must be set otherwise the existing one will still be used even after cancellation
         xpc_connection_set_event_handler(self.anonymousListenerConnection, { _ in })

--- a/Sources/SecureXPC/Server/XPCAnonymousServer.swift
+++ b/Sources/SecureXPC/Server/XPCAnonymousServer.swift
@@ -33,6 +33,13 @@ internal class XPCAnonymousServer: XPCServer {
             endpoint: xpc_endpoint_create(self.anonymousListenerConnection)
         )
     }
+    
+    // This exists for testing purposes
+    internal func shutdown() {
+        xpc_connection_cancel(self.anonymousListenerConnection)
+        // A new event handler must be set otherwise the existing one will still be used even after cancellation
+        xpc_connection_set_event_handler(self.anonymousListenerConnection, { _ in })
+    }
 }
 
 extension XPCAnonymousServer: NonBlockingStartable {

--- a/Sources/SecureXPC/XPCError.swift
+++ b/Sources/SecureXPC/XPCError.swift
@@ -27,6 +27,10 @@ public enum XPCError: Error, Codable {
     /// In practice this error is not expected to be encountered as this framework only supports XPC Mach service connections; this error applies to XPC Services
     /// which use a different type of connection.
     case terminationImminent
+    /// The connection to the server has already experienced an interruption and cannot be reestablished under any circumstances.
+    ///
+    /// This is expected behavior when attempting to send a message to an anonymous server after the connection has been interrupted.
+    case connectionCannotBeReestablished
     /// A request was not accepted by the server because it did not meet the server's security requirements or the server could not determine the identity of the
     /// client.
     case insecure

--- a/Tests/SecureXPCTests/Client & Server/Server Termination Integration Test.swift
+++ b/Tests/SecureXPCTests/Client & Server/Server Termination Integration Test.swift
@@ -1,0 +1,72 @@
+//
+//  Server Termination Integration Test.swift
+//  SecureXPC
+//
+//  Created by Josh Kaplan on 2022-01-10
+//
+
+import XCTest
+@testable import SecureXPC
+
+class ServerTerminationIntegrationTest: XCTestCase {
+
+    let dummyRequirements: [SecRequirement] = {
+        var requirement: SecRequirement?
+        // This is a worthless security requirement which should always result in the connection being accepted
+        SecRequirementCreateWithString("info [CFBundleVersion] exists" as CFString, SecCSFlags(), &requirement)
+        
+        return [requirement!]
+    }()
+    
+    // This test is intended to simulate a server running in a different process and then that process terminating
+    func testShutdownServer() throws {
+        // Server & client setup
+        let echoRoute = XPCRouteWithMessageWithReply("echo", messageType: String.self, replyType: String.self)
+        let server = XPCServer.makeAnonymousService(clientRequirements: dummyRequirements)
+        try server.registerRoute(echoRoute) { msg in
+            return "echo: \(msg)"
+        }
+        server.start()
+        let client = XPCClient.forEndpoint(server.endpoint)
+        
+        // Send a message, which will result in the connection being established with the server
+        try client.sendMessage("1st message", route: echoRoute) { _ in }
+        
+        // Shut down the server, simulating the scenario of the process containing the server terminating
+        (server as! XPCAnonymousServer).shutdown()
+        
+        // Make two more calls after having shutdown the server:
+        // - The second call should fail upon trying to send the message, connection is interrupted
+        // - The third call (and any subsequent ones) should fail indicating no new connections can ever be established
+        let interruptedExpectation = self.expectation(description: "Second message results in an interrupted error")
+        let cannotBeReestablishedExpectation = self.expectation(description: "Third message can't be sent")
+        try client.sendMessage("2nd message", route: echoRoute) { response in
+            switch response {
+                case .failure(let error):
+                    switch error {
+                        case .connectionInterrupted:
+                            interruptedExpectation.fulfill()
+                            
+                            // make another call to the server and this should fail with connectionCannotBeReestablished
+                            do {
+                                try client.sendMessage("3rd message", route: echoRoute) { _ in }
+                                XCTFail("No error was thrown. \(XPCError.connectionCannotBeReestablished) should " +
+                                        "have been thrown.")
+                            } catch XPCError.connectionCannotBeReestablished {
+                                cannotBeReestablishedExpectation.fulfill()
+                            } catch {
+                                XCTFail("Unexpected error: \(error). \(XPCError.connectionCannotBeReestablished) " +
+                                        "should have been thrown.")
+                            }
+                        default:
+                            XCTFail("Unexpected error: \(error). \(XPCError.connectionInterrupted) should have been " +
+                                    "returned.")
+                    }
+                case .success(_):
+                    XCTFail("No error was returned. \(XPCError.connectionInterrupted) should have been returned.")
+            }
+        }
+        
+        self.waitForExpectations(timeout: 1)
+    }
+}


### PR DESCRIPTION
Fixes #37

Now when using trying to send a message to a no longer operational anonymous server after the connection has become interrupted, `XPCError.connectionCannotBeReestablished` will be thrown. "Server Termination Integration Test" has been written to validate this behavior.