### PR TITLE
Fix missing dispatch queue setting

### DIFF
--- a/Sources/SecureXPC/Server/XPCAnonymousServer.swift
+++ b/Sources/SecureXPC/Server/XPCAnonymousServer.swift
@@ -16,6 +16,8 @@ internal class XPCAnonymousServer: XPCServer {
     internal init(clientRequirements: [SecRequirement]) {
         self.anonymousListenerConnection = xpc_connection_create(nil, nil)
         self.messageAcceptor = SecureMessageAcceptor(requirements: clientRequirements)
+        super.init()
+        self.addConnection(self.anonymousListenerConnection)
     }
 
     internal override func acceptMessage(connection: xpc_connection_t, message: xpc_object_t) -> Bool {
@@ -43,6 +45,8 @@ extension XPCAnonymousServer: NonBlockingStartable {
             xpc_connection_set_event_handler(newClientConnection, { event in
                 self.handleEvent(connection: newClientConnection, event: event)
             })
+            xpc_connection_set_target_queue(newClientConnection, self.targetQueue)
+            self.addConnection(newClientConnection)
             xpc_connection_resume(newClientConnection)
         })
         xpc_connection_resume(self.anonymousListenerConnection)

--- a/Sources/SecureXPC/Server/XPCMachServer.swift
+++ b/Sources/SecureXPC/Server/XPCMachServer.swift
@@ -165,6 +165,8 @@ internal class XPCMachServer: XPCServer, NonBlockingStartable {
             xpc_connection_set_event_handler(connection, { event in
                 self.handleEvent(connection: connection, event: event)
             })
+            xpc_connection_set_target_queue(connection, self.targetQueue)
+            self.addConnection(connection)
             xpc_connection_resume(connection)
         })
         xpc_connection_resume(listenerConnection)


### PR DESCRIPTION
 - Anonymous server connections weren't having the dispatch queue being set at or able to be updated
 - Incoming connections for the Mach server weren't having their dispatch queue set or update

I realized this while working on #43, but wanted to address it separately