### PR TITLE
Create anonymous servers that only accept same process messages

### DIFF
--- a/Sources/SecureXPC/Server/MessageAcceptor.swift
+++ b/Sources/SecureXPC/Server/MessageAcceptor.swift
@@ -21,12 +21,14 @@ internal struct AlwaysAcceptingMessageAcceptor: MessageAcceptor {
 
 /// This is intended for use by `XPCAnonymousServer`
 internal struct SameProcessMessageAcceptor: MessageAcceptor {
-    /// This process's PID.
-    private static let processPID = getpid()
-    
     /// Accepts a message only if it is coming from this process.
     func acceptMessage(connection: xpc_connection_t, message: xpc_object_t) -> Bool {
-        SameProcessMessageAcceptor.processPID == xpc_connection_get_pid(connection)
+        // In the case of an XPCAnonymousServer, all of the connections must be created after the server itself was
+        // created. As such, the process containing the server must always exist first and so no other process can
+        // have the same PID while that process is still running. While it's possible the process now corresponding to
+        // the PID returned by xpc_connection_get_pid(...) is not the process that created the connection, there's no
+        // way for it fake being this process. Therefore for anonymous connections it's safe to directly compare PIDs.
+        getpid() == xpc_connection_get_pid(connection)
     }
 }
 

--- a/Sources/SecureXPC/Server/XPCAnonymousServer.swift
+++ b/Sources/SecureXPC/Server/XPCAnonymousServer.swift
@@ -10,16 +10,14 @@ import Foundation
 internal class XPCAnonymousServer: XPCServer {
     private let anonymousListenerConnection: xpc_connection_t
     
-    /// Determines if an incoming request can be handled based on the provided client requirements
-    private let messageAcceptor: SecureMessageAcceptor
-
-    internal init(clientRequirements: [SecRequirement]) {
-        self.anonymousListenerConnection = xpc_connection_create(nil, nil)
-        self.messageAcceptor = SecureMessageAcceptor(requirements: clientRequirements)
+    private let _messageAcceptor: MessageAcceptor
+    override internal var messageAcceptor: MessageAcceptor {
+        _messageAcceptor
     }
 
-    internal override func acceptMessage(connection: xpc_connection_t, message: xpc_object_t) -> Bool {
-        self.messageAcceptor.acceptMessage(connection: connection, message: message)
+    internal init(messageAcceptor: MessageAcceptor) {
+        self._messageAcceptor = messageAcceptor
+        self.anonymousListenerConnection = xpc_connection_create(nil, nil)
     }
 
     /// Begins processing requests received by this XPC server and never returns.

--- a/Sources/SecureXPC/Server/XPCServiceServer.swift
+++ b/Sources/SecureXPC/Server/XPCServiceServer.swift
@@ -12,6 +12,12 @@ import Foundation
 /// In the case of this framework, the XPC Service is expected to be communicated with by an `XPCServiceClient`.
 internal class XPCServiceServer: XPCServer {
 	private static let service = XPCServiceServer()
+    
+    private let _messageAcceptor = AlwaysAcceptingMessageAcceptor()
+    override internal var messageAcceptor: MessageAcceptor {
+        _messageAcceptor
+    }
+    
     private var connection: xpc_connection_t? = nil
 
     internal static func _forThisXPCService() throws -> XPCServiceServer {
@@ -63,11 +69,6 @@ internal class XPCServiceServer: XPCServer {
 			      xpc_connection_resume(connection)
         }
     }
-
-	internal override func acceptMessage(connection: xpc_connection_t, message: xpc_object_t) -> Bool {
-		// XPC services are application-scoped, so we're assuming they're inheritently safe
-		true
-	}
 
     public override var serviceName: String? {
         xpcServiceName

--- a/Tests/SecureXPCTests/Client & Server/Round-trip Integration Test.swift
+++ b/Tests/SecureXPCTests/Client & Server/Round-trip Integration Test.swift
@@ -10,16 +10,8 @@ import XCTest
 
 class RoundTripIntegrationTest: XCTestCase {
     var xpcClient: XPCClient! = nil
-
-    static let dummyRequirements: [SecRequirement] = {
-        var requirement: SecRequirement?
-        // This is a worthless security requirement which should always result in the connection being accepted
-        SecRequirementCreateWithString("info [CFBundleVersion] exists" as CFString, SecCSFlags(), &requirement)
-        
-        return [requirement!]
-    }()
     
-    let anonymousServer = XPCServer.makeAnonymousService(clientRequirements: RoundTripIntegrationTest.dummyRequirements)
+    let anonymousServer = XPCServer.makeAnonymousService()
 
     override func setUp() {
         let endpoint = anonymousServer.endpoint


### PR DESCRIPTION
This is likely a common use case for an anonymous server, so this makes it easier to create while preserving security

As part of this PR, this also changes to having a `MessageAcceptor` protocol as previously discussed. It does add a bit of code in some places, but overall I think it's now the cleanest approach with there being three different acceptance "strategies".