### PR TITLE
Removes references to "service" in conjunction with "anonymous"

### DIFF
--- a/Sources/SecureXPC/Client/XPCAnonymousClient.swift
+++ b/Sources/SecureXPC/Client/XPCAnonymousClient.swift
@@ -1,5 +1,5 @@
 //
-//  XPCAnonymousServiceClient.swift
+//  XPCAnonymousClient.swift
 //  SecureXPC
 //
 //  Created by Alexander Momchilov on 2021-12-04
@@ -7,13 +7,13 @@
 
 import Foundation
 
-/// A concrete implementation of ``XPCClient`` which can communicate with an anonymous XPC service.
+/// A concrete implementation of ``XPCClient`` which can communicate with an anonymous XPC listener connection.
 ///
-/// In the case of this framework, the anonymous service is expected to be represented by an `XPCAnonymousServer`.
-internal class XPCAnonymousServiceClient: XPCClient {
+/// In the case of this framework, the anonymous listener connection is expected to be represented by an `XPCAnonymousServer`.
+internal class XPCAnonymousClient: XPCClient {
     override var serviceName: String? { nil }
 
-    // Anonymous service clients *must* be created from an existing connection.
+    // Anonymous clients *must* be created from an existing connection.
     init(connection: xpc_connection_t) {
         super.init(connection: connection)
     }

--- a/Sources/SecureXPC/Client/XPCClient.swift
+++ b/Sources/SecureXPC/Client/XPCClient.swift
@@ -135,7 +135,7 @@ public class XPCClient {
         xpc_connection_resume(connection)
 
         switch endpoint.serviceDescriptor {
-        case .anonymous: return XPCAnonymousServiceClient(connection: connection)
+        case .anonymous: return XPCAnonymousClient(connection: connection)
         case .xpcService(name: let name): return XPCServiceClient(xpcServiceName: name, connection: connection)
         case .machService(name: let name): return XPCMachClient(machServiceName: name, connection: connection)
         }

--- a/Sources/SecureXPC/Server/XPCServer.swift
+++ b/Sources/SecureXPC/Server/XPCServer.swift
@@ -113,13 +113,11 @@ public class XPCServer {
     }
     
     /// Creates a new anonymous server that only accepts connections from the same process it's running in.
-    internal static func makeAnonymousService() -> XPCServer & NonBlockingStartable {
+    internal static func makeAnonymous() -> XPCServer & NonBlockingStartable {
         XPCAnonymousServer(messageAcceptor: SameProcessMessageAcceptor())
     }
 
-    internal static func makeAnonymousService(
-        clientRequirements: [SecRequirement]
-    ) -> XPCServer & NonBlockingStartable {
+    internal static func makeAnonymous(clientRequirements: [SecRequirement]) -> XPCServer & NonBlockingStartable {
         XPCAnonymousServer(messageAcceptor: SecureMessageAcceptor(requirements: clientRequirements))
     }
     

--- a/Tests/SecureXPCTests/Client & Server/Round-trip Integration Test.swift
+++ b/Tests/SecureXPCTests/Client & Server/Round-trip Integration Test.swift
@@ -11,7 +11,7 @@ import XCTest
 class RoundTripIntegrationTest: XCTestCase {
     var xpcClient: XPCClient! = nil
     
-    let anonymousServer = XPCServer.makeAnonymousService()
+    let anonymousServer = XPCServer.makeAnonymous()
 
     override func setUp() {
         let endpoint = anonymousServer.endpoint

--- a/Tests/SecureXPCTests/Client & Server/Server Termination Integration Test.swift
+++ b/Tests/SecureXPCTests/Client & Server/Server Termination Integration Test.swift
@@ -22,7 +22,7 @@ class ServerTerminationIntegrationTest: XCTestCase {
     func testShutdownServer() throws {
         // Server & client setup
         let echoRoute = XPCRouteWithMessageWithReply("echo", messageType: String.self, replyType: String.self)
-        let server = XPCServer.makeAnonymousService(clientRequirements: dummyRequirements)
+        let server = XPCServer.makeAnonymous(clientRequirements: dummyRequirements)
         try server.registerRoute(echoRoute) { msg in
             return "echo: \(msg)"
         }


### PR DESCRIPTION
Anonymous connections have no service, which is a key distinguishing factor from XPC Services and Mach services.