### PR TITLE
Fixes a racy connection finalizer issue exposed by `testShutdownServer`

### DIFF
--- a/Sources/SecureXPC/Server/XPCServer.swift
+++ b/Sources/SecureXPC/Server/XPCServer.swift
@@ -291,7 +291,7 @@ public class XPCServer {
         // Keep a weak reference to the connection and this server, setting this as the context on the connection
         let weakConnection = WeakConnection(connection, server: self)
         self.connections.insert(weakConnection)
-        xpc_connection_set_context(connection, Unmanaged.passUnretained(weakConnection).toOpaque())
+        xpc_connection_set_context(connection, Unmanaged.passRetained(weakConnection).toOpaque())
         
         // The finalizer is called when the connection's retain count has reached zero, so now we need to remove the
         // wrapper from the containing connections array
@@ -300,7 +300,7 @@ public class XPCServer {
                 fatalError("Connection with retain count of zero is missing context, this should never happen")
             }
             
-            let weakConnection = Unmanaged<WeakConnection>.fromOpaque(opaqueWeakConnection).takeUnretainedValue()
+            let weakConnection = Unmanaged<WeakConnection>.fromOpaque(opaqueWeakConnection).takeRetainedValue()
             weakConnection.removeFromContainer()
         })
     }


### PR DESCRIPTION
It turns out occassionally `ServerTerminationIntegrationTest`'s `testShutdownServer` would result in a segfault inside of the finalizer for the connection. I'm pretty sure the issue was that a retained count needs to be taken for the WeakConnection instance (what we don't want to do is add a retain count to the connection itself).