### PR TITLE
Removes `endpoint` from `XPCServer` as it can't be supported by `XPCServicesServer`

### DIFF
--- a/Sources/SecureXPC/Server/XPCAnonymousServer.swift
+++ b/Sources/SecureXPC/Server/XPCAnonymousServer.swift
@@ -27,13 +27,6 @@ internal class XPCAnonymousServer: XPCServer {
         fatalError("startAndBlock() is not supported for anonymous connections. Use start() instead.")
     }
 
-    public override var endpoint: XPCServerEndpoint {
-        XPCServerEndpoint(
-            serviceDescriptor: .anonymous,
-            endpoint: xpc_endpoint_create(self.anonymousListenerConnection)
-        )
-    }
-    
     internal func simulateDisconnectionForTesting() {
         xpc_connection_cancel(self.anonymousListenerConnection)
         // A new event handler must be set otherwise the existing one will still be used even after cancellation
@@ -41,7 +34,7 @@ internal class XPCAnonymousServer: XPCServer {
     }
 }
 
-extension XPCAnonymousServer: NonBlockingStartable {
+extension XPCAnonymousServer: NonBlockingServer {
     public func start() {
         // Start listener for the new anonymous connection, all received events should be for incoming client connections
         xpc_connection_set_event_handler(anonymousListenerConnection, { newClientConnection in
@@ -54,5 +47,12 @@ extension XPCAnonymousServer: NonBlockingStartable {
             xpc_connection_resume(newClientConnection)
         })
         xpc_connection_resume(self.anonymousListenerConnection)
+    }
+    
+    public var endpoint: XPCServerEndpoint {
+        XPCServerEndpoint(
+            serviceDescriptor: .anonymous,
+            endpoint: xpc_endpoint_create(self.anonymousListenerConnection)
+        )
     }
 }

--- a/Sources/SecureXPC/Server/XPCMachServer.swift
+++ b/Sources/SecureXPC/Server/XPCMachServer.swift
@@ -10,7 +10,7 @@ import Foundation
 /// A concrete implementation of ``XPCServer`` which acts as a server for an XPC Mach service.
 ///
 /// In the case of this framework, the XPC Service is expected to be communicated with by an `XPCMachClient`.
-internal class XPCMachServer: XPCServer, NonBlockingStartable {
+internal class XPCMachServer: XPCServer {
     
     /// Name of the service.
     private let machServiceName: String
@@ -162,6 +162,15 @@ internal class XPCMachServer: XPCServer, NonBlockingStartable {
 		}
 	}
     
+	public override func startAndBlock() -> Never {
+        self.start()
+
+        // Park the main thread, allowing for incoming connections and requests to be processed
+        dispatchMain()
+	}
+}
+
+extension XPCMachServer: NonBlockingServer {
     public func start() {
         // Set listener for the Mach service, all received events will be incoming connections
         xpc_connection_set_event_handler(listenerConnection, { connection in
@@ -176,14 +185,7 @@ internal class XPCMachServer: XPCServer, NonBlockingStartable {
         xpc_connection_resume(listenerConnection)
     }
     
-	public override func startAndBlock() -> Never {
-        self.start()
-
-        // Park the main thread, allowing for incoming connections and requests to be processed
-        dispatchMain()
-	}
-
-    public override var endpoint: XPCServerEndpoint {
+    public var endpoint: XPCServerEndpoint {
         XPCServerEndpoint(
             serviceDescriptor: .machService(name: self.machServiceName),
             endpoint: xpc_endpoint_create(self.listenerConnection)

--- a/Sources/SecureXPC/Server/XPCServer.swift
+++ b/Sources/SecureXPC/Server/XPCServer.swift
@@ -396,6 +396,15 @@ public protocol NonBlockingServer {
     func start()
     /// Use an endpoint to create connections to this server
     var endpoint: XPCServerEndpoint { get }
+    
+    // Internal implementation note: `endpoint` is part of the `NonBlockingServer` protocol instead of `XPCServer` as
+    // `XPCServiceServer` can't have an endpoint created for it.
+    
+    // From a technical perspective this is because endpoints are only created from connection listeners, which an XPC
+    // Service doesn't expose (incoming connections are simply passed to the handler provided to `xpc_main(...)`. From
+    // a security point of view, it makes sense that it's not possible to create an endpoint for an XPC Service because
+    // they're designed to only allow communication between the main app and .xpc bundles contained within the same
+    // main app's bundle. As such there's no valid use case for creating such an endpoint.
 }
 
 // MARK: handler function wrappers

--- a/Sources/SecureXPC/Server/XPCServer.swift
+++ b/Sources/SecureXPC/Server/XPCServer.swift
@@ -300,7 +300,7 @@ public class XPCServer {
                 fatalError("Connection with retain count of zero is missing context, this should never happen")
             }
             
-            let weakConnection = Unmanaged<WeakConnection>.fromOpaque(opaqueWeakConnection).taketexetainedValue()
+            let weakConnection = Unmanaged<WeakConnection>.fromOpaque(opaqueWeakConnection).takeUnretainedValue()
             weakConnection.removeFromContainer()
         })
     }

--- a/Sources/SecureXPC/Server/XPCServer.swift
+++ b/Sources/SecureXPC/Server/XPCServer.swift
@@ -113,13 +113,13 @@ public class XPCServer {
     }
     
     /// Creates a new anonymous server that only accepts connections from the same process it's running in.
-    internal static func makeAnonymousService() -> XPCServer & NonBlockingStartable {
+    internal static func makeAnonymousService() -> XPCServer & NonBlockingServer {
         XPCAnonymousServer(messageAcceptor: SameProcessMessageAcceptor())
     }
 
     internal static func makeAnonymousService(
         clientRequirements: [SecRequirement]
-    ) -> XPCServer & NonBlockingStartable {
+    ) -> XPCServer & NonBlockingServer {
         XPCAnonymousServer(messageAcceptor: SecureMessageAcceptor(requirements: clientRequirements))
     }
     
@@ -141,7 +141,7 @@ public class XPCServer {
     ///
     /// - Throws: ``XPCError/misconfiguredBlessedHelperTool(_:)`` if the configuration does not match this function's requirements.
     /// - Returns: A server instance configured with the embedded property list entries.
-    public static func forThisBlessedHelperTool() throws -> XPCServer & NonBlockingStartable {
+    public static func forThisBlessedHelperTool() throws -> XPCServer & NonBlockingServer {
         try XPCMachServer._forThisBlessedHelperTool()
     }
 
@@ -176,7 +176,7 @@ public class XPCServer {
     public static func forThisMachService(
         named machServiceName: String,
         clientRequirements: [SecRequirement]
-    ) throws -> XPCServer & NonBlockingStartable {
+    ) throws -> XPCServer & NonBlockingServer {
         try XPCMachServer.getXPCMachServer(named: machServiceName, clientRequirements: clientRequirements)
     }
 
@@ -300,7 +300,7 @@ public class XPCServer {
                 fatalError("Connection with retain count of zero is missing context, this should never happen")
             }
             
-            let weakConnection = Unmanaged<WeakConnection>.fromOpaque(opaqueWeakConnection).takeUnretainedValue()
+            let weakConnection = Unmanaged<WeakConnection>.fromOpaque(opaqueWeakConnection).taketexetainedValue()
             weakConnection.removeFromContainer()
         })
     }
@@ -379,28 +379,12 @@ public class XPCServer {
         fatalError("Abstract Method")
     }
     
-	/// Determines whether the message should be accepted.
-	///
-	/// This is determined using the client requirements provided to this server upon initialization.
-	/// - Parameters:
-	///   - connection: The connection the message was sent over.
-	///   - message: The message.
-	/// - Returns: whether the message can be accepted
-    /*
-	internal func acceptMessage(connection: xpc_connection_t, message: xpc_object_t) -> Bool {
-		fatalError("Abstract Method")
-	}*/
-    
     internal var messageAcceptor: MessageAcceptor {
         fatalError("Abstract Property")
     }
 
     public var serviceName: String? {
         fatalError("Abstract Property")
-    }
-
-    public var endpoint: XPCServerEndpoint {
-        fatalError("Abstract Method")
     }
 }
 
@@ -409,9 +393,11 @@ public class XPCServer {
 /// An ``XPCServer`` which can be started in a non-blocking manner.
 ///
 /// > Warning: Do not implement this protocol. Additions made to this protocol will not be considered a breaking change for SemVer purposes.
-public protocol NonBlockingStartable {
+public protocol NonBlockingServer {
     /// Begins processing requests received by this XPC server.
     func start()
+    /// Use an endpoint to create connections to this server
+    var endpoint: XPCServerEndpoint { get }
 }
 
 // MARK: handler function wrappers

--- a/Sources/SecureXPC/Server/XPCServer.swift
+++ b/Sources/SecureXPC/Server/XPCServer.swift
@@ -73,7 +73,7 @@ import Foundation
 /// server.startAndBlock()
 /// ```
 ///
-/// Returned server instances which conform to ``NonBlockingStartable`` can also be started in a non-blocking manner:
+/// Returned server instances which conform to ``NonBlockingServer`` can also be started in a non-blocking manner:
 /// ```swift
 /// server.start()
 /// ```
@@ -92,7 +92,7 @@ import Foundation
 ///
 /// ### Starting a Server
 /// - ``startAndBlock()``
-/// - ``NonBlockingStartable/start()``
+/// - ``NonBlockingServer/start()``
 ///
 /// ### Error Handling
 /// - ``errorHandler``
@@ -137,7 +137,7 @@ public class XPCServer {
     ///
     /// Incoming requests will be accepted from clients that meet _any_ of the `SMAuthorizedClients` requirements.
     ///
-    /// > Important: No requests will be processed until ``startAndBlock()`` or ``NonBlockingStartable/start()`` is called.
+    /// > Important: No requests will be processed until ``startAndBlock()`` or ``NonBlockingServer/start()`` is called.
     ///
     /// - Throws: ``XPCError/misconfiguredBlessedHelperTool(_:)`` if the configuration does not match this function's requirements.
     /// - Returns: A server instance configured with the embedded property list entries.
@@ -166,7 +166,7 @@ public class XPCServer {
     /// }
     /// ```
     ///
-    /// > Important: No requests will be processed until ``startAndBlock()`` or ``NonBlockingStartable/start()`` is called.
+    /// > Important: No requests will be processed until ``startAndBlock()`` or ``NonBlockingServer/start()`` is called.
     ///
     /// - Parameters:
     ///   - named: The name of the mach service this server should bind to. This name must be present in the launchd property list's `MachServices` entry.

--- a/Sources/SecureXPC/Server/XPCServiceServer.swift
+++ b/Sources/SecureXPC/Server/XPCServiceServer.swift
@@ -73,16 +73,4 @@ internal class XPCServiceServer: XPCServer {
     public override var serviceName: String? {
         xpcServiceName
     }
-
-    public override var endpoint: XPCServerEndpoint {
-        guard let connection = self.connection else {
-            fatalError("An XPCServer's endpoint can only be retrieved after startAndBlock() has been called on it.")
-        }
-
-        let endpoint = xpc_endpoint_create(connection)
-        return XPCServerEndpoint(
-            serviceDescriptor: .xpcService(name: self.xpcServiceName),
-            endpoint: endpoint
-        )
-    }
 }


### PR DESCRIPTION
Fixes #46

`NonBlockingStartable` has been renamed to `NonBlockingServer` and `endpoint` was added to it. Not sure this is the best name for the protocol, but good enough for putting this up for review.