### PR TITLE
`XPCAnonymousServer` now supports `startAndBlock()`

### DIFF
--- a/Sources/SecureXPC/Server/XPCAnonymousServer.swift
+++ b/Sources/SecureXPC/Server/XPCAnonymousServer.swift
@@ -24,7 +24,8 @@ internal class XPCAnonymousServer: XPCServer {
 
     /// Begins processing requests received by this XPC server and never returns.
     public override func startAndBlock() -> Never {
-        fatalError("startAndBlock() is not supported for anonymous connections. Use start() instead.")
+        self.start()
+        dispatchMain()
     }
 
     internal func simulateDisconnectionForTesting() {

--- a/Sources/SecureXPC/Server/XPCServer.swift
+++ b/Sources/SecureXPC/Server/XPCServer.swift
@@ -372,7 +372,7 @@ public class XPCServer {
     /// If no value is specified, `dispatch_main` is the default. If `dispatch_main` is specified or defaulted to, it is a programming error to call this function
     /// from any thread besides the main thread.
     ///
-    /// If this server is for a Mach service, it is always a programming error to call this function from any thread besides the main thread.
+    /// If this server is for a Mach service or is an anonymous server, it is always a programming error to call this function from any thread besides the main thread.
     public func startAndBlock() -> Never {
         fatalError("Abstract Method")
     }


### PR DESCRIPTION
It now exactly mimics the implementation used by `XPCMachServer`. While in most cases this wouldn't be useful and `start()` should be used instead, by providing parity it means API users can test out running a Mach service (except for potentially the root access it has) with identical usage of SecureXPC.