### PR TITLE
Makes `XPCServerEndpoint` conform to `Codable`

### DIFF
--- a/Sources/SecureXPC/XPC Coders/XPCDecoder/XPCDecoderImpl.swift
+++ b/Sources/SecureXPC/XPC Coders/XPCDecoder/XPCDecoderImpl.swift
@@ -19,6 +19,13 @@ internal class XPCDecoderImpl: Decoder {
 		self.value = value
 		self.codingPath = codingPath
 	}
+    
+    // Internal implementation so that XPC-specific functions of the container can be accessed
+    internal func xpcContainer<Key>(
+        keyedBy type: Key.Type
+    ) throws -> XPCKeyedDecodingContainer<Key> where Key : CodingKey {
+        return try XPCKeyedDecodingContainer(value: self.value, codingPath: self.codingPath)
+    }
 
 	func container<Key>(keyedBy type: Key.Type) throws -> KeyedDecodingContainer<Key> where Key : CodingKey {
 		return KeyedDecodingContainer(try XPCKeyedDecodingContainer(value: self.value, codingPath: self.codingPath))

--- a/Sources/SecureXPC/XPC Coders/XPCDecoder/XPCKeyedDecodingContainer.swift
+++ b/Sources/SecureXPC/XPC Coders/XPCDecoder/XPCKeyedDecodingContainer.swift
@@ -165,16 +165,6 @@ internal class XPCKeyedDecodingContainer<K: CodingKey>: KeyedDecodingContainerPr
     // MARK: XPC specific decoding
     
     func decodeEndpoint(forKey key: K) throws -> xpc_endpoint_t {
-        let value = try value(forKey: key)
-        let valueType = xpc_get_type(value)
-        if valueType != XPC_TYPE_ENDPOINT {
-            let message = "Expected type: \(XPC_TYPE_ENDPOINT.description)\nActual type: \(valueType.description)"
-            let context = DecodingError.Context(codingPath: self.codingPath,
-                                                debugDescription: message,
-                                                underlyingError: nil)
-            throw DecodingError.typeMismatch(xpc_object_t.self, context)
-        }
-        
-        return value
+        return try decode(key: key, xpcType: XPC_TYPE_ENDPOINT, transform: {$0})
     }
 }

--- a/Sources/SecureXPC/XPC Coders/XPCDecoder/XPCKeyedDecodingContainer.swift
+++ b/Sources/SecureXPC/XPC Coders/XPCDecoder/XPCKeyedDecodingContainer.swift
@@ -161,4 +161,20 @@ internal class XPCKeyedDecodingContainer<K: CodingKey>: KeyedDecodingContainerPr
 	func superDecoder(forKey key: K) throws -> Decoder {
 		return XPCDecoderImpl(value: try value(forKey: key), codingPath: self.codingPath + [key])
 	}
+    
+    // MARK: XPC specific decoding
+    
+    func decodeEndpoint(forKey key: K) throws -> xpc_endpoint_t {
+        let value = try value(forKey: key)
+        let valueType = xpc_get_type(value)
+        if valueType != XPC_TYPE_ENDPOINT {
+            let message = "Expected type: \(XPC_TYPE_ENDPOINT.description)\nActual type: \(valueType.description)"
+            let context = DecodingError.Context(codingPath: self.codingPath,
+                                                debugDescription: message,
+                                                underlyingError: nil)
+            throw DecodingError.typeMismatch(xpc_object_t.self, context)
+        }
+        
+        return value
+    }
 }

--- a/Sources/SecureXPC/XPC Coders/XPCEncoder/XPCEncoderImpl.swift
+++ b/Sources/SecureXPC/XPC Coders/XPCEncoder/XPCEncoderImpl.swift
@@ -18,6 +18,14 @@ internal class XPCEncoderImpl: Encoder, XPCContainer {
 	init(codingPath: [CodingKey]) {
 		self.codingPath = codingPath
 	}
+    
+    // Internal implementation so that XPC-specific functions of the container can be accessed
+    internal func xpcContainer<Key>(keyedBy type: Key.Type) -> XPCKeyedEncodingContainer<Key> where Key: CodingKey {
+        let container = XPCKeyedEncodingContainer<Key>(codingPath: self.codingPath)
+        self.container = container
+        
+        return container
+    }
 
 	func container<Key>(keyedBy type: Key.Type) -> KeyedEncodingContainer<Key> where Key : CodingKey {
 		let container = XPCKeyedEncodingContainer<Key>(codingPath: self.codingPath)

--- a/Sources/SecureXPC/XPC Coders/XPCEncoder/XPCKeyedEncodingContainer.swift
+++ b/Sources/SecureXPC/XPC Coders/XPCEncoder/XPCKeyedEncodingContainer.swift
@@ -168,5 +168,11 @@ internal class XPCKeyedEncodingContainer<K>: KeyedEncodingContainerProtocol, XPC
 
 		return encoder
 	}
+    
+    // MARK: XPC specific encoding
+    
+    func encode(_ value: xpc_endpoint_t, forKey key: K) {
+        self.setValue(XPCObject(object: value), forKey: key)
+    }
 }
 

--- a/Sources/SecureXPC/XPCServerEndpoint.swift
+++ b/Sources/SecureXPC/XPCServerEndpoint.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 
-// TODO: make this codable so it can be sent over XPC.
 public struct XPCServerEndpoint {
     // Technically, an `xpc_endpoint_t` is sufficient to create a new connection, on its own. However, it's useful to
     // be able to communicate the kind of connection, and its name, so we also store those, separately.
@@ -18,4 +17,53 @@ public struct XPCServerEndpoint {
         self.serviceDescriptor = serviceDescriptor
         self.endpoint = endpoint
     }
+}
+
+extension XPCServerEndpoint: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(xpc_hash(self.endpoint))
+    }
+}
+
+extension XPCServerEndpoint: Equatable {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        // No need to compare service descriptors as the endpoint is guaranteed to be unique
+        xpc_equal(lhs.endpoint, rhs.endpoint)
+    }
+}
+
+// MARK: Codable
+
+private enum CodingKeys: String, CodingKey {
+    case serviceDescriptor
+    case endpoint
+}
+
+extension XPCServerEndpoint: Encodable {
+    public func encode(to encoder: Encoder) throws {
+        guard let xpcEncoder = encoder as? XPCEncoderImpl else {
+            throw XPCServerEndpointError.onlyEncodableBySecureXPCFramework
+        }
+        
+        let container = xpcEncoder.xpcContainer(keyedBy: CodingKeys.self)
+        try container.encode(self.serviceDescriptor, forKey: CodingKeys.serviceDescriptor)
+        container.encode(self.endpoint, forKey: CodingKeys.endpoint)
+    }
+}
+
+extension XPCServerEndpoint: Decodable {
+    public init(from decoder: Decoder) throws {
+        guard let xpcDecoder = decoder as? XPCDecoderImpl else {
+            throw XPCServerEndpointError.onlyDecodableBySecureXPCFramework
+        }
+        
+        let container = try xpcDecoder.xpcContainer(keyedBy: CodingKeys.self)
+        self.endpoint = try container.decodeEndpoint(forKey: CodingKeys.endpoint)
+        self.serviceDescriptor = try container.decode(XPCServiceDescriptor.self, forKey: CodingKeys.serviceDescriptor)
+    }
+}
+
+private enum XPCServerEndpointError: Error {
+    case onlyDecodableBySecureXPCFramework
+    case onlyEncodableBySecureXPCFramework
 }

--- a/Sources/SecureXPC/XPCServiceDescriptor.swift
+++ b/Sources/SecureXPC/XPCServiceDescriptor.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-internal enum XPCServiceDescriptor {
+internal enum XPCServiceDescriptor: Codable {
     case anonymous
     case xpcService(name: String)
     case machService(name: String)

--- a/Tests/SecureXPCTests/Encoder & Decoder/Round Trip/Endpoint roundtrip tests.swift
+++ b/Tests/SecureXPCTests/Encoder & Decoder/Round Trip/Endpoint roundtrip tests.swift
@@ -1,0 +1,23 @@
+//
+//  Endpoint roundtrip tests.swift
+//  SecureXPC
+//
+//  Created by Josh Kaplan on 2022-01-14
+//
+
+import XCTest
+@testable import SecureXPC
+
+final class XPCServerEndpointRoundtripTests: XCTestCase {
+    func testAnonymousRoundtripStartServerBeforehand() throws {
+        let server = XPCServer.makeAnonymous()
+        server.start()
+        try assertRoundTripEqual(server.endpoint)
+    }
+
+    func testAnonymousRoundtripStartServerAfterwards() throws {
+        let server = XPCServer.makeAnonymous()
+        try assertRoundTripEqual(server.endpoint)
+        server.start()
+    }
+}


### PR DESCRIPTION
Fixes #12 

Encoding and decoding "cheats" by using specific functions custom to `XPCEncoderImpl` and `XPCDecoderImpl`. As such if any other encoder or decoder tried to make use of these an error will be thrown.

Added two simple roundtrip tests to verify encoding and decoding works as expected for the anonymous server. However, this is a pretty limited test as it doesn't actually send the endpoint over an XPC connection.