### PR TITLE
Proper server deallocation, fixes issue #54

### DIFF
--- a/Sources/SecureXPC/Server/XPCServiceServer.swift
+++ b/Sources/SecureXPC/Server/XPCServiceServer.swift
@@ -17,8 +17,6 @@ internal class XPCServiceServer: XPCServer {
     override internal var messageAcceptor: MessageAcceptor {
         _messageAcceptor
     }
-    
-    private var connection: xpc_connection_t? = nil
 
     internal static func _forThisXPCService() throws -> XPCServiceServer {
         // An XPC Service's package type must be equal to "XPC!", see Apple's documentation for details
@@ -55,18 +53,10 @@ internal class XPCServiceServer: XPCServer {
     private lazy var xpcServiceName: String = Bundle.main.bundleIdentifier!
 
     public override func startAndBlock() -> Never {
-	      xpc_main { connection in
+        xpc_main { connection in
             // This is a @convention(c) closure, so we can't just capture `self`.
             // As such, the singleton reference `XPCServiceServer.service` is used instead.
-            xpc_connection_set_target_queue(connection, XPCServiceServer.service.targetQueue)
-            XPCServiceServer.service.connection = connection
-            XPCServiceServer.service.addConnection(connection)
-          
-            // Listen for events (messages or errors) coming from this connection
-            xpc_connection_set_event_handler(connection, { event in
-                XPCServiceServer.service.handleEvent(connection: connection, event: event)
-            })
-			      xpc_connection_resume(connection)
+            XPCServiceServer.service.startClientConnection(connection)
         }
     }
 

--- a/Tests/SecureXPCTests/Client & Server/XPCServer Creation.swift
+++ b/Tests/SecureXPCTests/Client & Server/XPCServer Creation.swift
@@ -8,8 +8,15 @@
 import Foundation
 import XCTest
 import SecureXPC
+@testable import SecureXPC
 
 final class XPCServerCreationTests: XCTestCase {
+    
+    func testCreateNeverStartedAnonymousServer() {
+        // This is testing that the server can succesfully be deallocated without it ever having been started
+        // See https://github.com/trilemma-dev/SecureXPC/issues/54
+        _ = XPCServer.makeAnonymous()
+    }
     
     func testFailToRetrieveServicesServer() {
         do {


### PR DESCRIPTION
`XPCAnonymousServer` and `XPCMachServer` now both start their listener connections in their initializers. However, now when incoming connections are received they don't unconditionally configure and start them. If the server has not been started, the connections are added to a pending array. Once the server is started, those pending connections are configured and started.

Summary of changes:
 - Consolidated all client connection to `XPCServer.startClientConnection(...)` which all three subclasses now call
 - Each instance of `XPCAnonymousServer` and `XPCMachServer` now has its own dispatch queue that it uses for both receiving connections as well as starting the server and processing pending connections, this should prevent race conditions. `XPCServer.targetQueue` now exclusively applies to running the handlers associated with the incoming client requests which makes more sense (and is actually what our own documentation says happens).
 - Added a seemingly trivial test which now passes, but without these changes always resulted in a SIGILL.