### PR TITLE
Optional completion handler `send` and `sendMessage` without reply

### DIFF
--- a/Sources/SecureXPC/Client/XPCClient.swift
+++ b/Sources/SecureXPC/Client/XPCClient.swift
@@ -60,7 +60,7 @@ import Foundation
 /// })
 /// ```
 ///
-/// The ``XPCClient/XPCReplyHandler`` provided to the `withReply` parameter is always passed a
+/// The ``XPCClient/XPCResponseHandler`` provided to the `withResponse` parameter is always passed a
 /// [`Result`](https://developer.apple.com/documentation/swift/result) with the `Success` value matching the route's `replyType` and a
 ///  `Failure` of type ``XPCError``. If an error was thrown by the server while handling the request, it will be provided as an ``XPCError`` on failure.
 ///
@@ -83,12 +83,12 @@ import Foundation
 /// - ``forXPCService(named:)``
 /// - ``forMachService(named:)``
 /// ### Calling Routes
-/// - ``send(route:)``
-/// - ``send(route:withReply:)``
-/// - ``sendMessage(_:route:)``
-/// - ``sendMessage(_:route:withReply:)``
-/// ### Receiving Replies
-/// - ``XPCReplyHandler``
+/// - ``send(route:onCompletion:)``
+/// - ``send(route:withResponse:)``
+/// - ``sendMessage(_:route:onCompletion:)``
+/// - ``sendMessage(_:route:withResponse:)``
+/// ### Receiving Responses
+/// - ``XPCResponseHandler``
 public class XPCClient {
     
     // MARK: Public factories
@@ -211,7 +211,7 @@ public class XPCClient {
     ///   - route: The server route which will handle this.
     ///   - withResponse: A function or closure to receive the response.
     public func send<R: Decodable>(route: XPCRouteWithoutMessageWithReply<R>,
-                                   withReply handler: @escaping XPCResponseHandler<R>) {
+                                   withResponse handler: @escaping XPCResponseHandler<R>) {
         do {
             let encoded = try Request(route: route.route).dictionary
             sendWithResponse(encoded: encoded, withResponse: handler)

--- a/Sources/SecureXPC/Client/XPCClient.swift
+++ b/Sources/SecureXPC/Client/XPCClient.swift
@@ -265,8 +265,8 @@ public class XPCClient {
                         result = .success(try response.decodePayload(asType: R.self))
                     } else if response.containsError {
                         result = .failure(try response.decodeError())
-                    } else if R.self == NoPayload.self { // Special case to handle when no payload is expected behavior
-                        result = .success(NoPayload.instance as! R)
+                    } else if R.self == EmptyResponse.self { // Special case for when an empty response is expected
+                        result = .success(EmptyResponse.instance as! R)
                     } else {
                         result = .failure(.unknown)
                     }
@@ -289,7 +289,7 @@ public class XPCClient {
     
     /// Wrapper that handles responses without a payload since `Void` is not `Decodable`
     private func sendWithResponse(encoded: xpc_object_t, withResponse handler: @escaping XPCResponseHandler<Void>) {
-        let wrappedHandler: XPCResponseHandler<NoPayload> = { response in
+        self.sendWithResponse(encoded: encoded) { (response: Result<EmptyResponse, XPCError>) -> Void in
             switch response {
                 case .success(_):
                     handler(.success(()))
@@ -297,11 +297,10 @@ public class XPCClient {
                     handler(.failure(error))
             }
         }
-        self.sendWithResponse(encoded: encoded, withResponse: wrappedHandler)
     }
     
-    /// Represents an XPC call which does not contain a payload in the response
-    fileprivate enum NoPayload: Decodable {
+    /// Represents an XPC call which does not contain a payload or error in the response
+    fileprivate enum EmptyResponse: Decodable {
         case instance
     }
     

--- a/Sources/SecureXPC/Routes.swift
+++ b/Sources/SecureXPC/Routes.swift
@@ -14,6 +14,10 @@ struct XPCRoute: Codable, Hashable {
     // These are intentionally excluded when computing equality and hash values as routes are uniqued only on path
     let messageType: String?
     let replyType: String?
+    /// Whether the route expects the handler registered on the server to have a non-`Void` type.
+    ///
+    /// The client may still request a response meaning that completion and any error that occurred can be sent back, but the handler is not expected to return data.
+    let expectsReply: Bool
     
     fileprivate init(pathComponents: [String], messageType: Any.Type?, replyType: Any.Type?) {
         self.pathComponents = pathComponents
@@ -26,8 +30,10 @@ struct XPCRoute: Codable, Hashable {
         
         if let replyType = replyType {
             self.replyType = String(describing: replyType)
+            self.expectsReply = (replyType.self != Void.self)
         } else {
             self.replyType = nil
+            self.expectsReply = false
         }
     }
     

--- a/Sources/SecureXPC/Server/XPCServer.swift
+++ b/Sources/SecureXPC/Server/XPCServer.swift
@@ -433,7 +433,6 @@ fileprivate extension XPCHandler {
                              messageType: Any.Type?,
                              replyType: Any.Type?) throws {
         var errorMessages = [String]()
-        
         // Message
         if messageType == nil, request.containsPayload {
             errorMessages.append("Request had a message of type \(String(describing: request.route.messageType)), " +
@@ -444,7 +443,7 @@ fileprivate extension XPCHandler {
         }
         
         // Reply
-        if replyType == nil, reply != nil {
+        if replyType == nil, reply != nil && request.route.expectsReply {
             errorMessages.append("Request expects a reply of type \(String(describing: request.route.replyType)), " +
                                  "but the handler registered with the server has no return value.")
         } else if let replyType = replyType, reply == nil {


### PR DESCRIPTION
Fixes #17

All `send` and `sendMessage` functions now take in a `XPCResponseHandler` (renamed from `XPCReplyHandler`). For those that require a reply, the response handler is non-optional. For those that can't have a reply, they can optionally provide a `XPCResponseHandler<Void>` which will get called upon successful completion or be provided an `XPCError` on failure.

In all cases, none of the functions now `throw` - all errors generated are provided to their handlers (or ignored if no handler is provided).

Three existing tests were modified and two new tests have been added.

---

This has been designed in a way which should make it relatively straightforward to address #19.