### PR TITLE
Misc improvements throughout the code base

### DIFF
--- a/Sources/SecureXPC/Client/XPCClient.swift
+++ b/Sources/SecureXPC/Client/XPCClient.swift
@@ -10,15 +10,15 @@ import Foundation
 /// An XPC client to make requests and receive responses from an ``XPCServer``.
 ///
 /// ### Retrieving a Client
-/// There are two different types of services you can communicate with using this client: XPC Services and XPC Mach services. If you are uncertain which
+/// There are two different types of services you can communicate with using this client: XPC services and XPC Mach services. If you are uncertain which
 /// type of service you're using, it's likely an XPC Service.
 ///
 /// Clients can also be created from an ``XPCServerEndpoint`` which is the only way to create a client for an anonymous server.
 ///
-/// #### XPC Services
+/// #### XPC services
 /// These are helper tools which ship as part of your app and only your app can communicate with.
 ///
-/// The name of the service must be specified when retrieving a client to talk to your XPC Service; this is always the bundle identifier for the service:
+/// The name of the service must be specified when retrieving a client to talk to your XPC service; this is always the bundle identifier for the service:
 /// ```swift
 /// let client = XPCClient.forXPCService(named: "com.example.myapp.service")
 /// ```
@@ -137,14 +137,14 @@ public class XPCClient {
     
     // MARK: Public factories
     
-    /// Provides a client to communicate with an XPC Service.
+    /// Provides a client to communicate with an XPC service.
     ///
-    /// An XPC Service is a helper tool which ships as part of your app and only your app can communicate with.
+    /// An XPC service is a helper tool which ships as part of your app and only your app can communicate with.
     ///
-    /// In order for this client to be able to communicate with the XPC Service, the service itself must retrieve and configure an ``XPCServer`` by calling
+    /// In order for this client to be able to communicate with the XPC service, the service itself must retrieve and configure an ``XPCServer`` by calling
     /// ``XPCServer/forThisXPCService()``.
     ///
-    /// > Note: Client creation always succeeds regardless of whether the XPC Service actually exists.
+    /// > Note: Client creation always succeeds regardless of whether the XPC service actually exists.
     ///
     /// - Parameters:
     ///   - named: The bundle identifier of the XPC Service.

--- a/Sources/SecureXPC/Client/XPCServiceClient.swift
+++ b/Sources/SecureXPC/Client/XPCServiceClient.swift
@@ -7,9 +7,9 @@
 
 import Foundation
 
-/// A concrete implementation of ``XPCClient`` which can communicate with an XPC Service.
+/// A concrete implementation of ``XPCClient`` which can communicate with an XPC service.
 ///
-/// In the case of this framework, the XPC Service is expected to be represented by an `XPCServiceServer`.
+/// In the case of this framework, the XPC service is expected to be represented by an `XPCServiceServer`.
 internal class XPCServiceClient: XPCClient {
     private let xpcServiceName: String
 

--- a/Sources/SecureXPC/SecureXPC.docc/SecureXPC.md
+++ b/Sources/SecureXPC/SecureXPC.docc/SecureXPC.md
@@ -6,7 +6,7 @@ compatability.
 ## Overview
 
 SecureXPC provides an easy way to perform secure XPC communication with pure Swift. `Codable` conforming types are used
-to make requests and receive responses. This framework can be used to communicate with any type of XPC Service or XPC
+to make requests and receive responses. This framework can be used to communicate with any type of XPC service or XPC
 Mach service. Customized support for communicating with helper tools installed via 
 [`SMJobBless`](https://developer.apple.com/documentation/servicemanagement/1431078-smjobbless) is also provided.
 
@@ -19,8 +19,9 @@ these routes.
 
 In a file shared by the client and server define one or more routes:
 ```swift
-let route = XPCRoute.named("bedazzle").withMessageType(String.self)
-                                      .withReplyType(Bool.self)
+let route = XPCRoute.named("bedazzle")
+                    .withMessageType(String.self)
+                    .withReplyType(Bool.self)
 ```
 See ``XPCRoute`` to learn more about how to create routes.
 

--- a/Sources/SecureXPC/Server/MessageAcceptor.swift
+++ b/Sources/SecureXPC/Server/MessageAcceptor.swift
@@ -7,19 +7,23 @@
 
 import Foundation
 
-protocol MessageAcceptor {
+internal protocol MessageAcceptor {
     /// Determines whether an incoming message should be accepted.
     func acceptMessage(connection: xpc_connection_t, message: xpc_object_t) -> Bool
 }
 
-/// This should only be used by XPC Services which are application-scoped, so it's safe to assume they're inheritently safe
+/// This should only be used by XPC services which are application-scoped, so it's safe to assume they're inheritently safe.
 internal struct AlwaysAcceptingMessageAcceptor: MessageAcceptor {
+    static let instance = AlwaysAcceptingMessageAcceptor()
+    
+    private init() { }
+    
     func acceptMessage(connection: xpc_connection_t, message: xpc_object_t) -> Bool {
         true
     }
 }
 
-/// This is intended for use by `XPCAnonymousServer`
+/// This is intended for use by `XPCAnonymousServer`.
 internal struct SameProcessMessageAcceptor: MessageAcceptor {
     /// Accepts a message only if it is coming from this process.
     func acceptMessage(connection: xpc_connection_t, message: xpc_object_t) -> Bool {

--- a/Sources/SecureXPC/Server/XPCServer.swift
+++ b/Sources/SecureXPC/Server/XPCServer.swift
@@ -10,15 +10,15 @@ import Foundation
 /// An XPC server to receive requests from and send responses to an ``XPCClient``.
 ///
 /// ### Retrieving a Server
-/// There are two different types of services you can retrieve a server for: XPC Services and XPC Mach services. If you're uncertain which type of service you're
-/// using, it's likely an XPC Service.
+/// There are two different types of services you can retrieve a server for: XPC services and XPC Mach services. If you're uncertain which type of service you're
+/// using, it's likely an XPC service.
 ///
-/// Anonymous servers can also be created which do not correspond to an XPC Service or XPC Mach service.
+/// Anonymous servers can also be created which do not correspond to an XPC service or XPC Mach service.
 ///
-/// #### XPC Services
+/// #### XPC services
 /// These are helper tools which ship as part of your app and only your app can communicate with.
 ///
-/// To retrieve a server for an XPC Service:
+/// To retrieve a server for an XPC service:
 /// ```swift
 /// let server = try XPCServer.forThisXPCService()
 /// ```
@@ -354,10 +354,8 @@ public class XPCServer {
                              reply: inout xpc_object_t?) {
         let error = XPCError.asXPCError(error: error, expectingOtherError: expectingOtherError)
         self.errorHandler?(error)
-        self.replyWithErrorIfPossible(error, connection: connection, reply: &reply)
-    }
-    
-    private func replyWithErrorIfPossible(_ error: XPCError, connection: xpc_connection_t, reply: inout xpc_object_t?) {
+        
+        // If it's possible to reply, then send the error back to the client
         if var reply = reply {
             do {
                 try Response.encodeError(error, intoReply: &reply)
@@ -372,7 +370,7 @@ public class XPCServer {
     
     /// Begins processing requests received by this XPC server and never returns.
     ///
-    /// If this server is for an XPC Service, how the server will run is determined by the info property list's
+    /// If this server is for an XPC service, how the server will run is determined by the info property list's
     /// [`RunLoopType`](https://developer.apple.com/documentation/bundleresources/information_property_list/xpcservice/runlooptype?changes=l_3).
     /// If no value is specified, `dispatch_main` is the default. If `dispatch_main` is specified or defaulted to, it is a programming error to call this function
     /// from any thread besides the main thread.
@@ -413,8 +411,8 @@ public protocol NonBlockingServer {
     // `XPCServiceServer` can't have an endpoint created for it.
     
     // From a technical perspective this is because endpoints are only created from connection listeners, which an XPC
-    // Service doesn't expose (incoming connections are simply passed to the handler provided to `xpc_main(...)`. From
-    // a security point of view, it makes sense that it's not possible to create an endpoint for an XPC Service because
+    // service doesn't expose (incoming connections are simply passed to the handler provided to `xpc_main(...)`. From
+    // a security point of view, it makes sense that it's not possible to create an endpoint for an XPC service because
     // they're designed to only allow communication between the main app and .xpc bundles contained within the same
     // main app's bundle. As such there's no valid use case for creating such an endpoint.
 }
@@ -423,14 +421,12 @@ public protocol NonBlockingServer {
 
 // Contains all of the `static` code that provides the entry points to retrieving an `XPCServer` instance.
 extension XPCServer {
-    /// Provides a server for this XPC Service.
-    ///
-    /// For the provided server to function properly, the caller must be an XPC Service.
+    /// Provides a server for this XPC service.
     ///
     /// > Important: No requests will be processed until ``startAndBlock()`` is called.
     ///
-    /// - Throws: ``XPCError/notXPCService`` if the caller is not an XPC Service.
-    /// - Returns: A server instance configured for this XPC Service.
+    /// - Throws: ``XPCError/notXPCService`` if the caller is not an XPC service.
+    /// - Returns: A server instance configured for this XPC service.
     public static func forThisXPCService() throws -> XPCServer {
         try XPCServiceServer._forThisXPCService()
     }

--- a/Sources/SecureXPC/XPCError.swift
+++ b/Sources/SecureXPC/XPCError.swift
@@ -9,23 +9,15 @@ import Foundation
 
 /// Errors that may be thrown when using ``XPCClient`` or ``XPCServer``.
 public enum XPCError: Error, Codable {
-    /// The connection was closed and can no longer be used; it may be possible to establish another connection.
+    /// The connection is not valid, but could be valid in the future.
     ///
-    /// Corresponds to
-    /// [`XPC_ERROR_CONNECTION_INVALID`](https://developer.apple.com/documentation/xpc/xpc_error_connection_invalid).
+    /// The connection could be invalid because the service is not installed or the service was updated, severing an existing connection.
     case connectionInvalid
     /// The connection experienced an interruption, but is still valid.
     ///
-    /// Corresponds to
-    /// [`XPC_ERROR_CONNECTION_INTERRUPTED`](https://developer.apple.com/documentation/xpc/xpc_error_connection_interrupted).
+    /// The next send may be able to successfully communicate with the server.
     case connectionInterrupted
     /// This XPC service will be terminated imminently.
-    ///
-    /// Corresponds to
-    /// [`XPC_ERROR_TERMINATION_IMMINENT`](https://developer.apple.com/documentation/xpc/xpc_error_termination_imminent).
-    ///
-    /// In practice this error is not expected to be encountered as this framework only supports XPC Mach service connections; this error applies to XPC Services
-    /// which use a different type of connection.
     case terminationImminent
     /// The connection to the server has already experienced an interruption and cannot be reestablished under any circumstances.
     ///
@@ -55,15 +47,15 @@ public enum XPCError: Error, Codable {
     case misconfiguredBlessedHelperTool(String)
     /// A server already exists for this named XPC Mach service and therefore another server can't be returned with different client requirements.
     case conflictingClientRequirements
-    /// The caller is not an XPC Service.
+    /// The caller is not an XPC service.
     ///
     /// This may mean there is a configuration issue. Alternatively it could be the caller is an XPC Mach service, in which case use
     /// ``XPCServer/forThisMachService(named:clientRequirements:)`` instead.
     case notXPCService
-    /// The caller is a misconfigured XPC Service.
+    /// The caller is a misconfigured XPC service.
     ///
-    /// Currently, this means that its bundle idenifiter was not set.
-    case misconfiguredXPCService
+    /// The associated string is a descriptive error message.
+    case misconfiguredXPCService(String)
     /// An error occurred that is not part of this framework, for example an error thrown by a handler registered with a ``XPCServer`` route. The associated
     /// value describes the error.
     case other(String)

--- a/Sources/SecureXPC/XPCServiceDescriptor.swift
+++ b/Sources/SecureXPC/XPCServiceDescriptor.swift
@@ -1,6 +1,6 @@
 //
 //  XPCServiceDescriptor.swift
-//  
+//  SecureXPC
 //
 //  Created by Alexander Momchilov on 2021-11-28.
 //

--- a/Tests/SecureXPCTests/Client & Server/Server Termination Integration Test.swift
+++ b/Tests/SecureXPCTests/Client & Server/Server Termination Integration Test.swift
@@ -19,52 +19,45 @@ class ServerTerminationIntegrationTest: XCTestCase {
     }()
     
     // This test is intended to simulate a server running in a different process and then that process terminating
-    func testShutdownServer() throws {
+    func testShutdownServer() async throws {
         // Server & client setup
-        let echoRoute = XPCRoute.named("echo").withMessageType(String.self).withReplyType(String.self)
+        let route = XPCRoute.named("doNothing")
         let server = XPCServer.makeAnonymous(clientRequirements: dummyRequirements)
-        try server.registerRoute(echoRoute) { msg in
-            return "echo: \(msg)"
-        }
+        try server.registerRoute(route) { }
         server.start()
         let client = XPCClient.forEndpoint(server.endpoint)
         
         // Send a message, which will result in the connection being established with the server
-        client.sendMessage("1st message", route: echoRoute) { _ in }
+        try await client.send(route: route)
         
         // Shut down the server, simulating the scenario of the process containing the server terminating
         (server as! XPCAnonymousServer).simulateDisconnectionForTesting()
         
-        // Make two more calls after having shutdown the server:
-        // - The second call should fail upon trying to send the message, connection is interrupted
-        // - The third call (and any subsequent ones) should fail indicating no new connections can ever be established
         let interruptedExpectation = self.expectation(description: "Second message results in an interrupted error")
-        let cannotBeReestablishedExpectation = self.expectation(description: "Third message can't be sent")
-        client.sendMessage("2nd message", route: echoRoute) { response in
-            switch response {
-                case .failure(.connectionInterrupted):
+        do {
+            try await client.send(route: route)
+        } catch {
+            switch error {
+                case XPCError.connectionInterrupted:
                     interruptedExpectation.fulfill()
-                    
-                    // make another call to the server and this should fail with connectionCannotBeReestablished
-                    client.sendMessage("3rd message", route: echoRoute) { response in
-                        switch response {
-                            case .failure(.connectionCannotBeReestablished):
-                                cannotBeReestablishedExpectation.fulfill()
-                            case .failure(let error):
-                                XCTFail("Unexpected error: \(error). \(XPCError.connectionCannotBeReestablished) " +
-                                        "should have been returned.")
-                            case .success(_):
-                                XCTFail("No error was returned. \(XPCError.connectionCannotBeReestablished) should " +
-                                        "have been returned.")
-                        }
-                    }
-                case .failure(let error):
-                    XCTFail("Unexpected error: \(error). \(XPCError.connectionInterrupted) should have been returned.")
-                case .success(_):
-                    XCTFail("No error was returned. \(XPCError.connectionInterrupted) should have been returned.")
+                default:
+                    XCTFail("Unexpected error: \(error). \(XPCError.connectionInterrupted) should have been thrown.")
             }
         }
         
-        self.waitForExpectations(timeout: 1)
+        let cannotBeReestablishedExpectation = self.expectation(description: "Third message can't establish connection")
+        do {
+            try await client.send(route: route)
+        } catch {
+            switch error {
+                case XPCError.connectionCannotBeReestablished:
+                    cannotBeReestablishedExpectation.fulfill()
+                default:
+                    XCTFail("Unexpected error: \(error). \(XPCError.connectionCannotBeReestablished) should have " +
+                            "been thrown.")
+            }
+        }
+        
+        await self.waitForExpectations(timeout: 1)
     }
 }


### PR DESCRIPTION
I realized they're actually called "XPC services" not "XPC Services", so have updated that throughout the comments (both public and internal)

The rest of the the changes are all misc code changes that I think improve things for the better. There's one small public facing change to `XPCError.misconfiguredXPCService` which now has a String to provide a descriptive error message.