### PR TITLE
Adds support for errors to optionally be part of a route's definition

### DIFF
--- a/Sources/SecureXPC/Client/XPCClient.swift
+++ b/Sources/SecureXPC/Client/XPCClient.swift
@@ -217,8 +217,8 @@ public class XPCClient {
                      onCompletion handler: XPCResponseHandler<Void>?) {
         if let handler = handler {
             do {
-                let encoded = try Request(route: route.route).dictionary
-                sendWithResponse(encoded: encoded, withResponse: handler)
+                let request = try Request(route: route.route)
+                sendRequest(request, withResponse: handler)
             } catch {
                 handler(.failure(.encodingError(String(describing: error))))
             }
@@ -238,7 +238,7 @@ public class XPCClient {
     public func send(route: XPCRouteWithoutMessageWithoutReply) async throws {
         try await withUnsafeThrowingContinuation { continuation in
             send(route: route) { response in
-                continuation.resume(with: response)
+                self.resumeContinuation(continuation, unwrappingResponse: response)
             }
         }
     }
@@ -254,8 +254,8 @@ public class XPCClient {
                                           onCompletion handler: XPCResponseHandler<Void>?) {
         if let handler = handler {
             do {
-                let encoded = try Request(route: route.route, payload: message).dictionary
-                sendWithResponse(encoded: encoded, withResponse: handler)
+                let request = try Request(route: route.route, payload: message)
+                sendRequest(request, withResponse: handler)
             } catch {
                 handler(.failure(.encodingError(String(describing: error))))
             }
@@ -275,7 +275,7 @@ public class XPCClient {
     public func sendMessage<M: Encodable>(_ message: M, route: XPCRouteWithMessageWithoutReply<M>) async throws {
         try await withUnsafeThrowingContinuation { continuation in
             sendMessage(message, route: route) { response in
-                continuation.resume(with: response)
+                self.resumeContinuation(continuation, unwrappingResponse: response)
             }
         }
     }
@@ -288,8 +288,8 @@ public class XPCClient {
     public func send<R: Decodable>(route: XPCRouteWithoutMessageWithReply<R>,
                                    withResponse handler: @escaping XPCResponseHandler<R>) {
         do {
-            let encoded = try Request(route: route.route).dictionary
-            sendWithResponse(encoded: encoded, withResponse: handler)
+            let request = try Request(route: route.route)
+            sendRequest(request, withResponse: handler)
         } catch {
             handler(.failure(.encodingError(String(describing: error))))
         }
@@ -303,7 +303,7 @@ public class XPCClient {
     public func send<R: Decodable>(route: XPCRouteWithoutMessageWithReply<R>) async throws -> R {
         try await withUnsafeThrowingContinuation { continuation in
             send(route: route) { response in
-                continuation.resume(with: response)
+                self.resumeContinuation(continuation, unwrappingResponse: response)
             }
         }
     }
@@ -318,8 +318,8 @@ public class XPCClient {
                                                         route: XPCRouteWithMessageWithReply<M, R>,
                                                         withResponse handler: @escaping XPCResponseHandler<R>) {
         do {
-            let encoded = try Request(route: route.route, payload: message).dictionary
-            sendWithResponse(encoded: encoded, withResponse: handler)
+            let request = try Request(route: route.route, payload: message)
+            sendRequest(request, withResponse: handler)
         } catch {
             handler(.failure(.encodingError(String(describing: error))))
         }
@@ -335,29 +335,29 @@ public class XPCClient {
                                                         route: XPCRouteWithMessageWithReply<M, R>) async throws -> R {
         try await withUnsafeThrowingContinuation { continuation in
             sendMessage(message, route: route) { response in
-                continuation.resume(with: response)
+                self.resumeContinuation(continuation, unwrappingResponse: response)
             }
         }
     }
     
     /// Does the actual work of sending an XPC message which receives a response.
-    private func sendWithResponse<R: Decodable>(encoded: xpc_object_t,
-                                                withResponse handler: @escaping XPCResponseHandler<R>) {
+    private func sendRequest<R: Decodable>(_ request: Request,
+                                           withResponse handler: @escaping XPCResponseHandler<R>) {
         // Get the connection or inform the handler of failure and return
         let connection: xpc_connection_t
         do {
             connection = try getConnection()
         } catch {
-            handler(.failure(XPCError.asXPCError(error: error, expectingOtherError: false)))
+            handler(.failure(XPCError.asXPCError(error: error)))
             return
         }
         
         // Async send the message over XPC
-        xpc_connection_send_message_with_reply(connection, encoded, nil) { reply in
+        xpc_connection_send_message_with_reply(connection, request.dictionary, nil) { reply in
             let result: Result<R, XPCError>
             if xpc_get_type(reply) == XPC_TYPE_DICTIONARY {
                 do {
-                    let response = try Response(dictionary: reply)
+                    let response = try Response(dictionary: reply, route: request.route)
                     if response.containsPayload {
                         result = .success(try response.decodePayload(asType: R.self))
                     } else if response.containsError {
@@ -368,7 +368,7 @@ public class XPCClient {
                         result = .failure(.unknown)
                     }
                 } catch {
-                    result = .failure(XPCError.asXPCError(error: error, expectingOtherError: false))
+                    result = .failure(XPCError.asXPCError(error: error))
                 }
             } else {
                 result = .failure(XPCError.fromXPCObject(reply))
@@ -379,8 +379,8 @@ public class XPCClient {
     }
     
     /// Wrapper that handles responses without a payload since `Void` is not `Decodable`
-    private func sendWithResponse(encoded: xpc_object_t, withResponse handler: @escaping XPCResponseHandler<Void>) {
-        self.sendWithResponse(encoded: encoded) { (response: Result<EmptyResponse, XPCError>) -> Void in
+    private func sendRequest(_ request: Request, withResponse handler: @escaping XPCResponseHandler<Void>) {
+        self.sendRequest(request) { (response: Result<EmptyResponse, XPCError>) -> Void in
             switch response {
                 case .success(_):
                     handler(.success(()))
@@ -395,14 +395,19 @@ public class XPCClient {
         case instance
     }
     
-    @available(macOS 10.15.0, *)
-    private func sendWithResponse<R: Decodable>(encoded: xpc_object_t) async throws -> R {
-        try await withCheckedThrowingContinuation { continuation in
-            sendWithResponse(encoded: encoded) { response in
-                continuation.resume(with: response)
-            }
+    /// Resumes the continuation while unwrapping any underlying errors thrown by a server's handler.
+    @available(macOS 10.15, *)
+    private func resumeContinuation<T>(_ contination: UnsafeContinuation<T, Error>,
+                                       unwrappingResponse response: Result<T, XPCError>) {
+        if case let .failure(error) = response,
+           case let .handlerError(handlerError) = error,
+           let underlyingError = handlerError.underlyingError {
+            contination.resume(throwing: underlyingError)
+        } else {
+            contination.resume(with: response)
         }
     }
+
     
     private func getConnection() throws -> xpc_connection_t {
         if let existingConnection = self.connection { return existingConnection }

--- a/Sources/SecureXPC/Client/XPCClient.swift
+++ b/Sources/SecureXPC/Client/XPCClient.swift
@@ -401,7 +401,7 @@ public class XPCClient {
                                        unwrappingResponse response: Result<T, XPCError>) {
         if case let .failure(error) = response,
            case let .handlerError(handlerError) = error,
-           let underlyingError = handlerError.underlyingError {
+           case let .available(underlyingError) = handlerError.underlyingError {
             contination.resume(throwing: underlyingError)
         } else {
             contination.resume(with: response)

--- a/Sources/SecureXPC/HandlerError.swift
+++ b/Sources/SecureXPC/HandlerError.swift
@@ -14,7 +14,8 @@ public struct HandlerError: Error {
     public enum UnderlyingError {
         /// The underlying error is available and is the associated type of this case.
         ///
-        /// This will always be the case on the server; however, on the client the other cases represented by this ``UnderlyingError`` may occur.
+        /// This will always be the case on the server; however, on the client the other cases represented by this
+        /// ``HandlerError/UnderlyingError-swift.enum`` may occur.
         case available(Error)
         /// The error was not encoded by the server and so there is no possibility of the client decoding it.
         case unavailableNotEncoded

--- a/Sources/SecureXPC/HandlerError.swift
+++ b/Sources/SecureXPC/HandlerError.swift
@@ -1,0 +1,110 @@
+//
+//  HandlerError.swift
+//  SecureXPC
+//
+//  Created by Josh Kaplan on 2022-02-06
+//
+
+import Foundation
+
+/// Represents an error thrown by a server's handler when processing a client's request.
+public struct HandlerError: Error {
+    /// The localized description of the underlying error.
+    public let localizedDescription: String
+    /// The error thrown by the handler.
+    ///
+    /// This error will always be present on the server; however, it will only exist on the client if it could be encoded by the server and decoded by the client.
+    public let underlyingError: Error?
+    /// The name of the underlying error's type within the server's runtime.
+    ///
+    /// Used to disambiguate enum case name conflicts when decoding.
+    private let typeName: String
+    
+    private init(error: Error) {
+        self.underlyingError = error
+        self.localizedDescription = error.localizedDescription
+        self.typeName = String(describing: type(of: error))
+    }
+    
+    /// Wrap calls to an ``XPCServer``'s handlers in this.
+    static func rethrow<T>(_ handler: () throws -> T) throws -> T {
+        do {
+            return try handler()
+        } catch {
+            throw HandlerError(error: error)
+        }
+    }
+    
+    /// Wrap calls to an ``XPCServer``'s `async` handlers in this.
+    @available(macOS 10.15.0, *)
+    static func rethrow<T>(_ handler: () async throws -> T) async throws -> T {
+        do {
+            return try await handler()
+        } catch {
+            throw HandlerError(error: error)
+        }
+    }
+}
+
+extension HandlerError: Codable {
+    private enum CodingKeys: CodingKey {
+        case localizedDescription
+        case typeName
+        case underlyingError
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.localizedDescription, forKey: .localizedDescription)
+        try container.encode(self.typeName, forKey: .typeName)
+        
+        if let underlyingError = underlyingError as? Codable {
+            // This is a bit hacky - we're "abusing" the ability to get a new encoder for a superclass and instead
+            // using it to have the error encode itself
+            let superEncoder = container.superEncoder(forKey: .underlyingError)
+            try underlyingError.encode(to: superEncoder)
+        }
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.localizedDescription = try container.decode(String.self, forKey: .localizedDescription)
+        self.typeName = try container.decode(String.self, forKey: .typeName)
+        
+        // Attempt to decode the actual error; however, it may not have been encoded or it may not be possible on the
+        // client to decode it (for example because we don't know what to decode it to)
+        do {
+            // This is the other side of the hacky coding we're doing to "abuse" the superclass encoder/decoder
+            let superDecoder = try container.superDecoder(forKey: .underlyingError)
+            guard let route = decoder.userInfo[XPCRoute.codingUserInfoKey] as? XPCRoute else {
+                fatalError("Decoding process failed to add \(XPCRoute.self) to userInfo.")
+            }
+            
+            // It's not that hard to end up with an error that could be decoded successfully as more than one type
+            // of error (see tests for an example). This is because for enum based errors, the default encoding is
+            // just the name of the case (and any associated values), so if the same case name exists in both enums
+            // and they don't have an associated value (or the associated value types are the same) then it's valid
+            // decoding.
+            // To better handle this case, the name of the error's type will also be used to aide disambiguation.
+            var decodedErrorsCount = 0
+            var decodedErrors = [String : Error]()
+            for errorType in route.errorTypes {
+                do {
+                    decodedErrors[String(describing: errorType)] = try errorType.init(from: superDecoder)
+                    decodedErrorsCount += 1
+                } catch { } // it's expected some decodings may fail
+            }
+            
+            // Decoded errors for two or more errors that have the same type name, so can't know which one is correct
+            if decodedErrorsCount != decodedErrors.count {
+                self.underlyingError = nil
+            } else if let error = decodedErrors[self.typeName] {
+                self.underlyingError = error
+            } else {
+                self.underlyingError = nil
+            }
+        } catch {
+            self.underlyingError = nil
+        }
+    }
+}

--- a/Sources/SecureXPC/HandlerError.swift
+++ b/Sources/SecureXPC/HandlerError.swift
@@ -9,19 +9,34 @@ import Foundation
 
 /// Represents an error thrown by a server's handler when processing a client's request.
 public struct HandlerError: Error {
+    
+    /// Wrapper around the actual error thrown by the server or an explanation of why it is not available.
+    public enum UnderlyingError {
+        /// The underlying error is available and is the associated type of this case.
+        ///
+        /// This will always be the case on the server; however, on the client the other cases represented by this ``UnderlyingError`` may occur.
+        case available(Error)
+        /// The error was not encoded by the server and so there is no possibility of the client decoding it.
+        case unavailableNotEncoded
+        /// The error was encoded by the server, but the route had no error types specified which could decode it.
+        case unavailableNoDecodingPossible
+        /// The error was encoded by the server, but the route had multiple error types specified which could decode it.
+        ///
+        /// Because there were multiple types which could decode it, the client cannot know which one is valid.
+        case unavailableMultipleDecodingsPossible
+    }
+    
     /// The localized description of the underlying error.
     public let localizedDescription: String
-    /// The error thrown by the handler.
-    ///
-    /// This error will always be present on the server; however, it will only exist on the client if it could be encoded by the server and decoded by the client.
-    public let underlyingError: Error?
+    /// Wrapper around the actual error thrown by the handler and whether it exists in this process.
+    public let underlyingError: UnderlyingError
     /// The name of the underlying error's type within the server's runtime.
     ///
     /// Used to disambiguate enum case name conflicts when decoding.
     private let typeName: String
     
     private init(error: Error) {
-        self.underlyingError = error
+        self.underlyingError = .available(error)
         self.localizedDescription = error.localizedDescription
         self.typeName = String(describing: type(of: error))
     }
@@ -58,7 +73,8 @@ extension HandlerError: Codable {
         try container.encode(self.localizedDescription, forKey: .localizedDescription)
         try container.encode(self.typeName, forKey: .typeName)
         
-        if let underlyingError = underlyingError as? Codable {
+        if case let .available(underlyingError) = underlyingError,
+           let underlyingError = underlyingError as? Codable {
             // This is a bit hacky - we're "abusing" the ability to get a new encoder for a superclass and instead
             // using it to have the error encode itself
             let superEncoder = container.superEncoder(forKey: .underlyingError)
@@ -71,40 +87,41 @@ extension HandlerError: Codable {
         self.localizedDescription = try container.decode(String.self, forKey: .localizedDescription)
         self.typeName = try container.decode(String.self, forKey: .typeName)
         
-        // Attempt to decode the actual error; however, it may not have been encoded or it may not be possible on the
-        // client to decode it (for example because we don't know what to decode it to)
+        // This is the other side of the hacky coding we're doing to "abuse" the superclass encoder/decoder
+        let superDecoder: Decoder
         do {
-            // This is the other side of the hacky coding we're doing to "abuse" the superclass encoder/decoder
-            let superDecoder = try container.superDecoder(forKey: .underlyingError)
-            guard let route = decoder.userInfo[XPCRoute.codingUserInfoKey] as? XPCRoute else {
-                fatalError("Decoding process failed to add \(XPCRoute.self) to userInfo.")
-            }
-            
-            // It's not that hard to end up with an error that could be decoded successfully as more than one type
-            // of error (see tests for an example). This is because for enum based errors, the default encoding is
-            // just the name of the case (and any associated values), so if the same case name exists in both enums
-            // and they don't have an associated value (or the associated value types are the same) then it's valid
-            // decoding.
-            // To better handle this case, the name of the error's type will also be used to aide disambiguation.
-            var decodedErrorsCount = 0
-            var decodedErrors = [String : Error]()
-            for errorType in route.errorTypes {
-                do {
-                    decodedErrors[String(describing: errorType)] = try errorType.init(from: superDecoder)
-                    decodedErrorsCount += 1
-                } catch { } // it's expected some decodings may fail
-            }
-            
-            // Decoded errors for two or more errors that have the same type name, so can't know which one is correct
-            if decodedErrorsCount != decodedErrors.count {
-                self.underlyingError = nil
-            } else if let error = decodedErrors[self.typeName] {
-                self.underlyingError = error
-            } else {
-                self.underlyingError = nil
-            }
+            superDecoder = try container.superDecoder(forKey: .underlyingError)
         } catch {
-            self.underlyingError = nil
+            self.underlyingError = .unavailableNotEncoded
+            return
+        }
+        
+        guard let route = decoder.userInfo[XPCRoute.codingUserInfoKey] as? XPCRoute else {
+            fatalError("Decoding process failed to add \(XPCRoute.self) to userInfo.")
+        }
+        
+        // It's not that hard to end up with an error that could be decoded successfully as more than one type of error
+        // (see tests for an example). This is because for enum based errors, the default encoding is just the name of
+        // the case (and any associated values), so if the same case name exists in both enums and they don't have an
+        // associated value (or the associated value types are the same) then it's valid decoding.
+        //
+        // To better handle this case, the name of the error's type will also be used to aide disambiguation.
+        var decodedErrorsCount = 0
+        var decodedErrors = [String : Error]()
+        for errorType in route.errorTypes {
+            do {
+                decodedErrors[String(describing: errorType)] = try errorType.init(from: superDecoder)
+                decodedErrorsCount += 1
+            } catch { } // it's expected some decodings may fail
+        }
+        
+        // Decoded errors for two or more errors that have the same type name, so can't know which one is correct
+        if decodedErrorsCount != decodedErrors.count {
+            self.underlyingError = .unavailableMultipleDecodingsPossible
+        } else if let error = decodedErrors[self.typeName] {
+            self.underlyingError = .available(error)
+        } else {
+            self.underlyingError = .unavailableNoDecodingPossible
         }
     }
 }

--- a/Sources/SecureXPC/Response.swift
+++ b/Sources/SecureXPC/Response.swift
@@ -18,6 +18,8 @@ struct Response {
         static let payload: XPCDictionaryKey = const("__payload")
     }
     
+    /// The route this response came from.
+    let route: XPCRoute
     /// The response encoded as an XPC dictionary.
     let dictionary: xpc_object_t
     /// Whether this response contains a payload.
@@ -28,8 +30,9 @@ struct Response {
     /// Represents a reply that's already been encoded into an XPC dictionary.
     ///
     /// This initializer is expected to be used by the client when receiving a reply which it now needs to decode.
-    init(dictionary: xpc_object_t) throws {
+    init(dictionary: xpc_object_t, route: XPCRoute) throws {
         self.dictionary = dictionary
+        self.route = route
         self.containsPayload = try XPCDecoder.containsKey(ResponseKeys.payload, inDictionary: dictionary)
         self.containsError = try XPCDecoder.containsKey(ResponseKeys.error, inDictionary: dictionary)
     }
@@ -62,6 +65,9 @@ struct Response {
     ///
     /// This is expected to be called from the client.
     func decodeError() throws -> XPCError {
-        return try XPCDecoder.decode(XPCError.self, from: self.dictionary, forKey: ResponseKeys.error)
+        return try XPCDecoder.decode(XPCError.self,
+                                     from: self.dictionary,
+                                     forKey: ResponseKeys.error,
+                                     userInfo: [XPCRoute.codingUserInfoKey : self.route])
     }
 }

--- a/Sources/SecureXPC/Routes.swift
+++ b/Sources/SecureXPC/Routes.swift
@@ -188,6 +188,7 @@ public struct XPCRouteWithoutMessageWithoutReply {
         XPCRouteWithoutMessageWithoutReply(self.route.pathComponents,
                                            errorTypes: self.route.errorTypes + [errorType])
     }
+    
     /// Creates a route which receives a message and will not reply.
     ///
     /// ``XPCRouteWithMessageWithoutReply/withReplyType(_:)`` can be called on it to create a route which is expected to reply.

--- a/Sources/SecureXPC/Routes.swift
+++ b/Sources/SecureXPC/Routes.swift
@@ -48,6 +48,7 @@ import Foundation
 /// let throttleRoute = XPCRoute.named("thermal", "throttle")
 ///                             .withMessageType(Int.self)
 ///                             .throwsType(ThermalError.self)
+///                             .throwsType(ConfigurationError.self)                             
 /// ```
 /// Any number of error types which are `Codable` may be specified.
 ///
@@ -179,12 +180,14 @@ public struct XPCRouteWithoutMessageWithoutReply {
     ///
     /// This function may be called multiple times to register multiple potential error types.
     ///
-    /// If an error type is specified using this function and the server throws an error of this, if the client used an `async` function then the specific error will be
-    /// rethrown. If a closure-based function was used, then it will be returned as an ``XPCError/handlerError(_:)`` with
-    /// ``HandlerError/underlyingError`` as the error thrown by the server.
+    /// For specified error types, if the client used an `async` function then the specific error will be rethrown. If a closure-based function was used, then it will be
+    /// returned as an ``XPCError/handlerError(_:)`` and ``HandlerError/UnderlyingError-swift.enum/available(_:)`` will contain the
+    /// specific error.
     ///
-    /// If the error type thrown by the server was not specified using this function, then ``HandlerError`` will represent the error, but
-    /// ``HandlerError/underlyingError`` will be `nil`. This will occur for both the `async` and closure-based functions.
+    /// If the error type thrown by the server was not specified using this function, then ``HandlerError`` will represent the error, and
+    /// ``HandlerError/underlyingError-swift.property`` will have a value of
+    /// ``HandlerError/UnderlyingError-swift.enum/unavailableNoDecodingPossible``. This will occur for both the `async` and
+    /// closure-based functions.
     public func throwsType<E: Error & Codable>(_ errorType: E.Type) -> XPCRouteWithoutMessageWithoutReply {
         XPCRouteWithoutMessageWithoutReply(self.route.pathComponents,
                                            errorTypes: self.route.errorTypes + [errorType])
@@ -231,12 +234,14 @@ public struct XPCRouteWithoutMessageWithReply<R: Codable> {
     ///
     /// This function may be called multiple times to register multiple potential error types.
     ///
-    /// If an error type is specified using this function and the server throws an error of this, if the client used an `async` function then the specific error will be
-    /// rethrown. If a closure-based function was used, then it will be returned as an ``XPCError/handlerError(_:)`` with
-    /// ``HandlerError/underlyingError`` as the error thrown by the server.
+    /// For specified error types, if the client used an `async` function then the specific error will be rethrown. If a closure-based function was used, then it will be
+    /// returned as an ``XPCError/handlerError(_:)`` and ``HandlerError/UnderlyingError-swift.enum/available(_:)`` will contain the
+    /// specific error.
     ///
-    /// If the error type thrown by the server was not specified using this function, then ``HandlerError`` will represent the error, but
-    /// ``HandlerError/underlyingError`` will be `nil`. This will occur for both the `async` and closure-based functions.
+    /// If the error type thrown by the server was not specified using this function, then ``HandlerError`` will represent the error, and
+    /// ``HandlerError/underlyingError-swift.property`` will have a value of
+    /// ``HandlerError/UnderlyingError-swift.enum/unavailableNoDecodingPossible``. This will occur for both the `async` and
+    /// closure-based functions.
     public func throwsType<E: Error & Codable>(_ errorType: E.Type) -> XPCRouteWithoutMessageWithReply {
         XPCRouteWithoutMessageWithReply(self.route.pathComponents,
                                         replyType: R.self,
@@ -274,12 +279,14 @@ public struct XPCRouteWithMessageWithoutReply<M: Codable> {
     ///
     /// This function may be called multiple times to register multiple potential error types.
     ///
-    /// If an error type is specified using this function and the server throws an error of this, if the client used an `async` function then the specific error will be
-    /// rethrown. If a closure-based function was used, then it will be returned as an ``XPCError/handlerError(_:)`` with
-    /// ``HandlerError/underlyingError`` as the error thrown by the server.
+    /// For specified error types, if the client used an `async` function then the specific error will be rethrown. If a closure-based function was used, then it will be
+    /// returned as an ``XPCError/handlerError(_:)`` and ``HandlerError/UnderlyingError-swift.enum/available(_:)`` will contain the
+    /// specific error.
     ///
-    /// If the error type thrown by the server was not specified using this function, then ``HandlerError`` will represent the error, but
-    /// ``HandlerError/underlyingError`` will be `nil`. This will occur for both the `async` and closure-based functions.
+    /// If the error type thrown by the server was not specified using this function, then ``HandlerError`` will represent the error, and
+    /// ``HandlerError/underlyingError-swift.property`` will have a value of
+    /// ``HandlerError/UnderlyingError-swift.enum/unavailableNoDecodingPossible``. This will occur for both the `async` and
+    /// closure-based functions.
     public func throwsType<E: Error & Codable>(_ errorType: E.Type) -> XPCRouteWithMessageWithoutReply {
         XPCRouteWithMessageWithoutReply(self.route.pathComponents,
                                         messageType: M.self,
@@ -321,12 +328,14 @@ public struct XPCRouteWithMessageWithReply<M: Codable, R: Codable> {
     ///
     /// This function may be called multiple times to register multiple potential error types.
     ///
-    /// If an error type is specified using this function and the server throws an error of this, if the client used an `async` function then the specific error will be
-    /// rethrown. If a closure-based function was used, then it will be returned as an ``XPCError/handlerError(_:)`` with
-    /// ``HandlerError/underlyingError`` as the error thrown by the server.
+    /// For specified error types, if the client used an `async` function then the specific error will be rethrown. If a closure-based function was used, then it will be
+    /// returned as an ``XPCError/handlerError(_:)`` and ``HandlerError/UnderlyingError-swift.enum/available(_:)`` will contain the
+    /// specific error.
     ///
-    /// If the error type thrown by the server was not specified using this function, then ``HandlerError`` will represent the error, but
-    /// ``HandlerError/underlyingError`` will be `nil`. This will occur for both the `async` and closure-based functions.
+    /// If the error type thrown by the server was not specified using this function, then ``HandlerError`` will represent the error, and
+    /// ``HandlerError/underlyingError-swift.property`` will have a value of
+    /// ``HandlerError/UnderlyingError-swift.enum/unavailableNoDecodingPossible``. This will occur for both the `async` and
+    /// closure-based functions.
     public func throwsType<E: Error & Codable>(_ errorType: E.Type) -> XPCRouteWithMessageWithReply {
         XPCRouteWithMessageWithReply(self.route.pathComponents,
                                      messageType: M.self,

--- a/Sources/SecureXPC/Routes.swift
+++ b/Sources/SecureXPC/Routes.swift
@@ -119,7 +119,7 @@ public struct XPCRoute {
     /// ``XPCRouteWithoutMessageWithoutReply/withReplyType(_:)`` can be called on the returned route to create a route which is expected to
     /// reply.
     public static func named(_ pathComponents: String...) -> XPCRouteWithoutMessageWithoutReply {
-        XPCRouteWithoutMessageWithoutReply(pathComponents, errorTypes: [(Error & Codable).Type]())
+        XPCRouteWithoutMessageWithoutReply(pathComponents, errorTypes: [])
     }
 }
 
@@ -140,6 +140,7 @@ extension XPCRoute: Codable {
         case messageType
         case replyType
         case expectsReply
+        // It is intentional errorTypes is not coded, see errorTypes declaration for explanation.
     }
     
     public func encode(to encoder: Encoder) throws {
@@ -156,7 +157,7 @@ extension XPCRoute: Codable {
         self.messageType = try container.decode(String?.self, forKey: .messageType)
         self.replyType = try container.decode(String?.self, forKey: .replyType)
         self.expectsReply = try container.decode(Bool.self, forKey: .expectsReply)
-        self.errorTypes = [(Error & Codable).Type]()
+        self.errorTypes = []
     }
 }
 

--- a/Sources/SecureXPC/Routes.swift
+++ b/Sources/SecureXPC/Routes.swift
@@ -12,8 +12,8 @@ import Foundation
 /// Client to server communication is performed using routes. A route is a sequence of `String`s and if applicable also the message and reply types.
 ///
 /// In practice a route is similar to a function signature or a server path with type safety. Message and reply types must be
-/// [`Codable`](https://developer.apple.com/documentation/swift/codable). Many structs, enums, and classes in the Swift
-/// standard library are already `Codable` and compiler generated conformance is available for simple structs and enums.
+/// [`Codable`](https://developer.apple.com/documentation/swift/codable). Many structs, enums, and classes in the Swift standard library are
+/// already `Codable` and compiler generated conformance is available for simple structs and enums.
 ///
 /// The simplest form of a route is one that contains neither a message nor a reply:
 /// ```swift
@@ -39,8 +39,17 @@ import Foundation
 ///                             .withReplyType(Int.self)
 /// ```
 ///
-/// Routes are distinct based on their names, meaning the last two routes above are considered equivalent. A server will
-/// only allow one handler to be registered for each distinct route.
+/// Routes are distinct based on their names, meaning the last two routes above are considered equivalent. A server will only allow one handler to be registered for
+/// each distinct route.
+///
+/// #### Errors
+/// Errors thrown by the handler registered for the route may optionally be specified:
+/// ```swift
+/// let throttleRoute = XPCRoute.named("thermal", "throttle")
+///                             .withMessageType(Int.self)
+///                             .throwsType(ThermalError.self)
+/// ```
+/// Any number of error types which are `Codable` may be specified.
 ///
 /// #### Storing Routes
 /// To ensure consistency, ideally routes are only defined once in code that is shared by both the client and server.
@@ -49,15 +58,18 @@ import Foundation
 /// Once a route has been created, it needs to be registered with an ``XPCServer`` in order for it to be called by an ``XPCClient``.
 ///
 /// #### Updating Routes
-/// If you are using XPC Mach services, take care when updating existing routes because over time you may end up with an
-/// older version of your server installed on a computer with a newer client. You may want to version your routes by
-/// prefixing them with a number:
+/// If you are using XPC Mach services, take care when updating existing routes because over time you may end up with an older version of your server installed on
+/// a computer with a newer client. You may want to version your routes by prefixing them with a number:
 /// ```swift
 /// XPCRoute.named("1", "reset")
 /// ```
 ///
 /// This is also applicable for routes registered with anonymous servers that allow requests from other processes.
-public struct XPCRoute: Codable {
+public struct XPCRoute {
+    
+    /// The key to be used when inserting or accessing an XPC route that's part of the coding process's user info
+    static let codingUserInfoKey = CodingUserInfoKey(rawValue: String(describing: XPCRoute.self))!
+    
     let pathComponents: [String]
     
     // These are intentionally excluded when computing equality and hash values as routes are uniqued only on path
@@ -65,10 +77,21 @@ public struct XPCRoute: Codable {
     let replyType: String?
     /// Whether the route expects the handler registered on the server to have a non-`Void` type.
     ///
-    /// The client may still request a response meaning that completion and any error that occurred can be sent back, but the handler is not expected to return data.
+    /// The client may still request a response meaning that completion and any error that occurred can be sent back, but the server's handler is not expected to
+    /// have a return type.
     let expectsReply: Bool
+    /// Types that the API user claims could be thrown by the server's handler registered with this route.
+    ///
+    /// There's no way to compile time enforce this is actually true; however, at runtime the client will attempt to decode an error to these types.
+    ///
+    /// This array of types is intentionally not encoded/decoded as there is no way to transfer actual Swift types between runtimes and we need the actual types, not
+    /// just textual descriptions of them. Since the server always attempts to encode any error it can, only the client actually needs these types.
+    let errorTypes: [(Error & Codable).Type]
     
-    fileprivate init(pathComponents: [String], messageType: Any.Type?, replyType: Any.Type?) {
+    fileprivate init(pathComponents: [String],
+                     messageType: Any.Type?,
+                     replyType: Any.Type?,
+                     errorTypes: [(Error & Codable).Type]) {
         self.pathComponents = pathComponents
         
         if let messageType = messageType {
@@ -84,6 +107,8 @@ public struct XPCRoute: Codable {
             self.replyType = nil
             self.expectsReply = false
         }
+        
+        self.errorTypes = errorTypes
     }
     
     /// Creates a route that can't receive a message and will not reply.
@@ -94,7 +119,7 @@ public struct XPCRoute: Codable {
     /// ``XPCRouteWithoutMessageWithoutReply/withReplyType(_:)`` can be called on the returned route to create a route which is expected to
     /// reply.
     public static func named(_ pathComponents: String...) -> XPCRouteWithoutMessageWithoutReply {
-        XPCRouteWithoutMessageWithoutReply(pathComponents)
+        XPCRouteWithoutMessageWithoutReply(pathComponents, errorTypes: [(Error & Codable).Type]())
     }
 }
 
@@ -108,6 +133,33 @@ extension XPCRoute: Hashable {
     }
 }
 
+// Custom codable implementation that exists to prevent encoding `errorTypes`.
+extension XPCRoute: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case pathComponents
+        case messageType
+        case replyType
+        case expectsReply
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.pathComponents, forKey: .pathComponents)
+        try container.encode(self.messageType, forKey: .messageType)
+        try container.encode(self.replyType, forKey: .replyType)
+        try container.encode(self.expectsReply, forKey: .expectsReply)
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.pathComponents = try container.decode([String].self, forKey: .pathComponents)
+        self.messageType = try container.decode(String?.self, forKey: .messageType)
+        self.replyType = try container.decode(String?.self, forKey: .replyType)
+        self.expectsReply = try container.decode(Bool.self, forKey: .expectsReply)
+        self.errorTypes = [(Error & Codable).Type]()
+    }
+}
+
 /// A route that can't receive a message and will not reply.
 ///
 /// See ``XPCRoute`` for how to create a route.
@@ -118,22 +170,40 @@ public struct XPCRouteWithoutMessageWithoutReply {
     ///
     /// - Parameters:
     ///   - _: Zero or more `String`s naming the route.
-    fileprivate init(_ pathComponents: [String]) {
-        self.route = XPCRoute(pathComponents: pathComponents, messageType: nil, replyType: nil)
+    fileprivate init(_ pathComponents: [String], errorTypes: [(Error & Codable).Type]) {
+        self.route = XPCRoute(pathComponents: pathComponents, messageType: nil, replyType: nil, errorTypes: errorTypes)
     }
     
+    /// Optionally specifies an `Error` type thrown by the handler registered for this route.
+    ///
+    /// This function may be called multiple times to register multiple potential error types.
+    ///
+    /// If an error type is specified using this function and the server throws an error of this, if the client used an `async` function then the specific error will be
+    /// rethrown. If a closure-based function was used, then it will be returned as an ``XPCError/handlerError(_:)`` with
+    /// ``HandlerError/underlyingError`` as the error thrown by the server.
+    ///
+    /// If the error type thrown by the server was not specified using this function, then ``HandlerError`` will represent the error, but
+    /// ``HandlerError/underlyingError`` will be `nil`. This will occur for both the `async` and closure-based functions.
+    public func throwsType<E: Error & Codable>(_ errorType: E.Type) -> XPCRouteWithoutMessageWithoutReply {
+        XPCRouteWithoutMessageWithoutReply(self.route.pathComponents,
+                                           errorTypes: self.route.errorTypes + [errorType])
+    }
     /// Creates a route which receives a message and will not reply.
     ///
     /// ``XPCRouteWithMessageWithoutReply/withReplyType(_:)`` can be called on it to create a route which is expected to reply.
     public func withMessageType<M: Codable>(_ messageType: M.Type) -> XPCRouteWithMessageWithoutReply<M> {
-        XPCRouteWithMessageWithoutReply(self.route.pathComponents, messageType: messageType)
+        XPCRouteWithMessageWithoutReply(self.route.pathComponents,
+                                        messageType: M.self,
+                                        errorTypes: self.route.errorTypes)
     }
     
     /// Creates a route that can't receive a message and is expected to reply.
     ///
     /// ``XPCRouteWithoutMessageWithReply/withMessageType(_:)`` can be called on the returned route to create a route that receives a message.
     public func withReplyType<R: Codable>(_ replyType: R.Type) -> XPCRouteWithoutMessageWithReply<R> {
-        XPCRouteWithoutMessageWithReply(self.route.pathComponents, replyType: replyType)
+        XPCRouteWithoutMessageWithReply(self.route.pathComponents,
+                                        replyType: R.self,
+                                        errorTypes: self.route.errorTypes)
     }
 }
 
@@ -142,21 +212,41 @@ public struct XPCRouteWithoutMessageWithoutReply {
 /// See ``XPCRoute`` for how to create a route.
 public struct XPCRouteWithoutMessageWithReply<R: Codable> {
     let route: XPCRoute
-    private let replyType: R.Type
     
     /// Initializes the route.
     ///
     /// - Parameters:
     ///   - _: Zero or more `String`s naming the route.
     ///   - replyType: The expected type the server will respond with if successful.
-    fileprivate init(_ pathComponents: [String], replyType: R.Type) {
-        self.route = XPCRoute(pathComponents: pathComponents, messageType: nil, replyType: replyType)
-        self.replyType = replyType
+    fileprivate init(_ pathComponents: [String], replyType: R.Type, errorTypes: [(Error & Codable).Type]) {
+        self.route = XPCRoute(pathComponents: pathComponents,
+                              messageType: nil,
+                              replyType: R.self,
+                              errorTypes: errorTypes)
+    }
+    
+    /// Optionally specifies an `Error` type thrown by the handler registered for this route.
+    ///
+    /// This function may be called multiple times to register multiple potential error types.
+    ///
+    /// If an error type is specified using this function and the server throws an error of this, if the client used an `async` function then the specific error will be
+    /// rethrown. If a closure-based function was used, then it will be returned as an ``XPCError/handlerError(_:)`` with
+    /// ``HandlerError/underlyingError`` as the error thrown by the server.
+    ///
+    /// If the error type thrown by the server was not specified using this function, then ``HandlerError`` will represent the error, but
+    /// ``HandlerError/underlyingError`` will be `nil`. This will occur for both the `async` and closure-based functions.
+    public func throwsType<E: Error & Codable>(_ errorType: E.Type) -> XPCRouteWithoutMessageWithReply {
+        XPCRouteWithoutMessageWithReply(self.route.pathComponents,
+                                        replyType: R.self,
+                                        errorTypes: self.route.errorTypes + [errorType])
     }
     
     /// Creates a route that receives a message and is expected to reply.
     public func withMessageType<M: Codable>(_ messageType: M.Type) -> XPCRouteWithMessageWithReply<M, R> {
-        XPCRouteWithMessageWithReply(self.route.pathComponents, messageType: messageType, replyType: self.replyType)
+        XPCRouteWithMessageWithReply(self.route.pathComponents,
+                                     messageType: M.self,
+                                     replyType: R.self,
+                                     errorTypes: self.route.errorTypes)
     }
 }
 
@@ -164,7 +254,6 @@ public struct XPCRouteWithoutMessageWithReply<R: Codable> {
 ///
 /// See ``XPCRoute`` for how to create a route.
 public struct XPCRouteWithMessageWithoutReply<M: Codable> {
-    private let messageType: M.Type
     let route: XPCRoute
     
     /// Initializes the route.
@@ -172,14 +261,35 @@ public struct XPCRouteWithMessageWithoutReply<M: Codable> {
     /// - Parameters:
     ///   - _: Zero or more `String`s naming the route.
     ///   - messageType: The expected type the client will be passed when sending a message to this route.
-    fileprivate init(_ pathComponents: [String], messageType: M.Type) {
-        self.route = XPCRoute(pathComponents: pathComponents, messageType: messageType, replyType: nil)
-        self.messageType = messageType
+    fileprivate init(_ pathComponents: [String], messageType: M.Type, errorTypes: [(Error & Codable).Type]) {
+        self.route = XPCRoute(pathComponents: pathComponents,
+                              messageType: M.self,
+                              replyType: nil,
+                              errorTypes: errorTypes)
+    }
+    
+    /// Optionally specifies an `Error` type thrown by the handler registered for this route.
+    ///
+    /// This function may be called multiple times to register multiple potential error types.
+    ///
+    /// If an error type is specified using this function and the server throws an error of this, if the client used an `async` function then the specific error will be
+    /// rethrown. If a closure-based function was used, then it will be returned as an ``XPCError/handlerError(_:)`` with
+    /// ``HandlerError/underlyingError`` as the error thrown by the server.
+    ///
+    /// If the error type thrown by the server was not specified using this function, then ``HandlerError`` will represent the error, but
+    /// ``HandlerError/underlyingError`` will be `nil`. This will occur for both the `async` and closure-based functions.
+    public func throwsType<E: Error & Codable>(_ errorType: E.Type) -> XPCRouteWithMessageWithoutReply {
+        XPCRouteWithMessageWithoutReply(self.route.pathComponents,
+                                        messageType: M.self,
+                                        errorTypes: self.route.errorTypes + [errorType])
     }
     
     /// Creates a route that receives a message and is expected to reply.
     public func withReplyType<R: Codable>(_ replyType: R.Type) -> XPCRouteWithMessageWithReply<M, R> {
-        XPCRouteWithMessageWithReply(self.route.pathComponents, messageType: self.messageType, replyType: replyType)
+        XPCRouteWithMessageWithReply(self.route.pathComponents,
+                                     messageType: M.self,
+                                     replyType: R.self,
+                                     errorTypes: self.route.errorTypes)
     }
 }
 
@@ -195,7 +305,30 @@ public struct XPCRouteWithMessageWithReply<M: Codable, R: Codable> {
     ///   - _: Zero or more `String`s naming the route.
     ///   - messageType: The expected type the client will be passed when sending a message to this route.
     ///   - replyType: The expected type the server will respond with if successful.
-    fileprivate init(_ pathComponents: [String], messageType: M.Type, replyType: R.Type) {
-        self.route = XPCRoute(pathComponents: pathComponents, messageType: messageType, replyType: replyType)
+    fileprivate init(_ pathComponents: [String],
+                     messageType: M.Type,
+                     replyType: R.Type,
+                     errorTypes: [(Error & Codable).Type]) {
+        self.route = XPCRoute(pathComponents: pathComponents,
+                              messageType: M.self,
+                              replyType: R.self,
+                              errorTypes: errorTypes)
+    }
+    
+    /// Optionally specifies an `Error` type thrown by the handler registered for this route.
+    ///
+    /// This function may be called multiple times to register multiple potential error types.
+    ///
+    /// If an error type is specified using this function and the server throws an error of this, if the client used an `async` function then the specific error will be
+    /// rethrown. If a closure-based function was used, then it will be returned as an ``XPCError/handlerError(_:)`` with
+    /// ``HandlerError/underlyingError`` as the error thrown by the server.
+    ///
+    /// If the error type thrown by the server was not specified using this function, then ``HandlerError`` will represent the error, but
+    /// ``HandlerError/underlyingError`` will be `nil`. This will occur for both the `async` and closure-based functions.
+    public func throwsType<E: Error & Codable>(_ errorType: E.Type) -> XPCRouteWithMessageWithReply {
+        XPCRouteWithMessageWithReply(self.route.pathComponents,
+                                     messageType: M.self,
+                                     replyType: R.self,
+                                     errorTypes: self.route.errorTypes + [errorType])
     }
 }

--- a/Sources/SecureXPC/SecureXPC.docc/SecureXPC.md
+++ b/Sources/SecureXPC/SecureXPC.docc/SecureXPC.md
@@ -74,3 +74,4 @@ See ``XPCClient`` for more on how to retrieve a client and send requests.
 
 ### Errors
 - ``XPCError``
+- ``HandlerError``

--- a/Sources/SecureXPC/Server/XPCServer.swift
+++ b/Sources/SecureXPC/Server/XPCServer.swift
@@ -61,9 +61,6 @@ import Foundation
 /// }
 /// ```
 ///
-/// If the function or closure throws an error and the route expects a return, then ``XPCError/other(_:)`` will be returned to the client with the `String`
-/// associated type describing the thrown error. It is intentional the thrown error is not marshalled as that type may not be `Codable` and may not exist in the client.
-///
 /// ### Starting a Server
 /// Once all of the routes are registered, the server must be told to start processing requests. In most cases this should be done with:
 /// ```swift

--- a/Sources/SecureXPC/Server/XPCServer.swift
+++ b/Sources/SecureXPC/Server/XPCServer.swift
@@ -309,14 +309,14 @@ public class XPCServer {
             request = try Request(dictionary: message)
         } catch {
             var reply = xpc_dictionary_create_reply(message)
-            self.handleError(error, expectingOtherError: false, connection: connection, reply: &reply)
+            self.handleError(error, connection: connection, reply: &reply)
             return
         }
         
         guard let handler = self.routes[request.route] else {
             let error = XPCError.routeNotRegistered(request.route.pathComponents)
             var reply = xpc_dictionary_create_reply(message)
-            self.handleError(error, expectingOtherError: false, connection: connection, reply: &reply)
+            self.handleError(error, connection: connection, reply: &reply)
             return
         }
         
@@ -330,7 +330,7 @@ public class XPCServer {
                     xpc_connection_send_message(connection, reply)
                 }
             } catch {
-                self.handleError(error, expectingOtherError: true, connection: connection, reply: &reply)
+                self.handleError(error, connection: connection, reply: &reply)
             }
             
         } else if #available(macOS 10.15.0, *), let handler = handler as? XPCHandlerAsync {
@@ -344,7 +344,7 @@ public class XPCServer {
                         xpc_connection_send_message(connection, reply)
                     }
                 } catch {
-                    self.handleError(error, expectingOtherError: true, connection: connection, reply: &reply)
+                    self.handleError(error, connection: connection, reply: &reply)
                 }
             }
         } else {
@@ -354,10 +354,9 @@ public class XPCServer {
     }
     
     private func handleError(_ error: Error,
-                             expectingOtherError: Bool,
                              connection: xpc_connection_t,
                              reply: inout xpc_object_t?) {
-        let error = XPCError.asXPCError(error: error, expectingOtherError: expectingOtherError)
+        let error = XPCError.asXPCError(error: error)
         self.errorHandler?(error)
         
         // If it's possible to reply, then send the error back to the client
@@ -611,7 +610,7 @@ fileprivate struct ConstrainedXPCHandlerWithoutMessageWithoutReplySync: XPCHandl
     
     func handle(request: Request, reply: inout xpc_object_t?) throws {
         try checkMatchesRequest(request, reply: &reply, messageType: nil, replyType: nil)
-        try self.handler()
+        try HandlerError.rethrow { try self.handler() }
     }
 }
 
@@ -621,7 +620,7 @@ fileprivate struct ConstrainedXPCHandlerWithMessageWithoutReplySync<M: Decodable
     func handle(request: Request, reply: inout xpc_object_t?) throws {
         try checkMatchesRequest(request, reply: &reply, messageType: M.self, replyType: nil)
         let decodedMessage = try request.decodePayload(asType: M.self)
-        try self.handler(decodedMessage)
+        try HandlerError.rethrow { try self.handler(decodedMessage) }
     }
 }
 
@@ -630,7 +629,7 @@ fileprivate struct ConstrainedXPCHandlerWithoutMessageWithReplySync<R: Encodable
     
     func handle(request: Request, reply: inout xpc_object_t?) throws {
         try checkMatchesRequest(request, reply: &reply, messageType: nil, replyType: R.self)
-        let payload = try self.handler()
+        let payload = try HandlerError.rethrow { try self.handler() }
         try Response.encodePayload(payload, intoReply: &reply!)
     }
 }
@@ -641,7 +640,7 @@ fileprivate struct ConstrainedXPCHandlerWithMessageWithReplySync<M: Decodable, R
     func handle(request: Request, reply: inout xpc_object_t?) throws {
         try checkMatchesRequest(request, reply: &reply, messageType: M.self, replyType: R.self)
         let decodedMessage = try request.decodePayload(asType: M.self)
-        let payload = try self.handler(decodedMessage)
+        let payload = try HandlerError.rethrow { try self.handler(decodedMessage) }
         try Response.encodePayload(payload, intoReply: &reply!)
     }
 }
@@ -659,7 +658,7 @@ fileprivate struct ConstrainedXPCHandlerWithoutMessageWithoutReplyAsync: XPCHand
     
     func handle(request: Request, reply: inout xpc_object_t?) async throws {
         try checkMatchesRequest(request, reply: &reply, messageType: nil, replyType: nil)
-        try await self.handler()
+        try await HandlerError.rethrow { try await self.handler() }
     }
 }
 
@@ -670,7 +669,7 @@ fileprivate struct ConstrainedXPCHandlerWithMessageWithoutReplyAsync<M: Decodabl
     func handle(request: Request, reply: inout xpc_object_t?) async throws {
         try checkMatchesRequest(request, reply: &reply, messageType: M.self, replyType: nil)
         let decodedMessage = try request.decodePayload(asType: M.self)
-        try await self.handler(decodedMessage)
+        try await HandlerError.rethrow { try await self.handler(decodedMessage) }
     }
 }
 
@@ -680,7 +679,7 @@ fileprivate struct ConstrainedXPCHandlerWithoutMessageWithReplyAsync<R: Encodabl
     
     func handle(request: Request, reply: inout xpc_object_t?) async throws {
         try checkMatchesRequest(request, reply: &reply, messageType: nil, replyType: R.self)
-        let payload = try await self.handler()
+        let payload = try await HandlerError.rethrow { try await self.handler() }
         try Response.encodePayload(payload, intoReply: &reply!)
     }
 }
@@ -692,7 +691,7 @@ fileprivate struct ConstrainedXPCHandlerWithMessageWithReplyAsync<M: Decodable, 
     func handle(request: Request, reply: inout xpc_object_t?) async throws {
         try checkMatchesRequest(request, reply: &reply, messageType: M.self, replyType: R.self)
         let decodedMessage = try request.decodePayload(asType: M.self)
-        let payload = try await self.handler(decodedMessage)
+        let payload = try await HandlerError.rethrow { try await self.handler(decodedMessage) }
         try Response.encodePayload(payload, intoReply: &reply!)
     }
 }

--- a/Sources/SecureXPC/XPC Coders/XPCDecoder/XPCDecoder.swift
+++ b/Sources/SecureXPC/XPC Coders/XPCDecoder/XPCDecoder.swift
@@ -29,15 +29,17 @@ enum XPCDecoder {
     ///  - _: The type to decode the XPC representation to.
     ///  - from: The XPC dictionary containing the value to decode.
     ///  - forKey: The key of the value in the XPC dictionary.
+    ///  - userInfo: An optional dictionary available during the decoding process.
     /// - Throws: If `from` isn't a dictionary, the `key` isn't present in the dictionary, or the decoding fails.
     /// - Returns: An instance of the provided type corresponding to the contents of the value for the provided key.
     static func decode<T: Decodable>(_ type: T.Type,
                                      from dictionary: xpc_object_t,
-                                     forKey key: XPCDictionaryKey) throws -> T {
+                                     forKey key: XPCDictionaryKey,
+                                     userInfo: [CodingUserInfoKey : Any] = [CodingUserInfoKey : Any]()) throws -> T {
         try checkXPCDictionary(object: dictionary)
         
         if let value = xpc_dictionary_get_value(dictionary, key) {
-            return try decode(type, object: value)
+            return try decode(type, object: value, userInfo: userInfo)
         } else {
             // Ideally this would throw DecodingError.keyNotFound(...) but that requires providing a CodingKey
             // and there isn't one yet
@@ -55,8 +57,12 @@ enum XPCDecoder {
     ///  - object: The XPC object.
     /// - Throws: If decoding fails.
     /// - Returns: An instance of the provided type corresponding to the object.
-    static func decode<T: Decodable>(_ type: T.Type, object: xpc_object_t) throws -> T {
-        return try T(from: XPCDecoderImpl(value: object, codingPath: [CodingKey]()))
+    static func decode<T: Decodable>(_ type: T.Type,
+                                     object: xpc_object_t,
+                                     userInfo: [CodingUserInfoKey : Any] = [CodingUserInfoKey : Any]()) throws -> T {
+        let decoder = XPCDecoderImpl(value: object, codingPath: [CodingKey](), userInfo: userInfo)
+        
+        return try T(from: decoder)
     }
     
     /// Throws an error if the provided XPC object is not an XPC dictionary.

--- a/Sources/SecureXPC/XPC Coders/XPCDecoder/XPCDecoder.swift
+++ b/Sources/SecureXPC/XPC Coders/XPCDecoder/XPCDecoder.swift
@@ -35,7 +35,7 @@ enum XPCDecoder {
     static func decode<T: Decodable>(_ type: T.Type,
                                      from dictionary: xpc_object_t,
                                      forKey key: XPCDictionaryKey,
-                                     userInfo: [CodingUserInfoKey : Any] = [CodingUserInfoKey : Any]()) throws -> T {
+                                     userInfo: [CodingUserInfoKey : Any] = [ : ]) throws -> T {
         try checkXPCDictionary(object: dictionary)
         
         if let value = xpc_dictionary_get_value(dictionary, key) {
@@ -59,7 +59,7 @@ enum XPCDecoder {
     /// - Returns: An instance of the provided type corresponding to the object.
     static func decode<T: Decodable>(_ type: T.Type,
                                      object: xpc_object_t,
-                                     userInfo: [CodingUserInfoKey : Any] = [CodingUserInfoKey : Any]()) throws -> T {
+                                     userInfo: [CodingUserInfoKey : Any] = [ : ]) throws -> T {
         let decoder = XPCDecoderImpl(value: object, codingPath: [CodingKey](), userInfo: userInfo)
         
         return try T(from: decoder)

--- a/Sources/SecureXPC/XPC Coders/XPCDecoder/XPCDecoderImpl.swift
+++ b/Sources/SecureXPC/XPC Coders/XPCDecoder/XPCDecoderImpl.swift
@@ -9,33 +9,37 @@ import Foundation
 
 internal class XPCDecoderImpl: Decoder {
 	var codingPath = [CodingKey]()
-
-	let userInfo = [CodingUserInfoKey : Any]()
-
+    let userInfo: [CodingUserInfoKey : Any]
 	private let value: xpc_object_t
 
-
-	init(value: xpc_object_t, codingPath: [CodingKey]) {
+    init(value: xpc_object_t, codingPath: [CodingKey], userInfo: [CodingUserInfoKey : Any]) {
 		self.value = value
 		self.codingPath = codingPath
+        self.userInfo = userInfo
 	}
     
     // Internal implementation so that XPC-specific functions of the container can be accessed
     internal func xpcContainer<Key>(
         keyedBy type: Key.Type
     ) throws -> XPCKeyedDecodingContainer<Key> where Key : CodingKey {
-        return try XPCKeyedDecodingContainer(value: self.value, codingPath: self.codingPath)
+        try XPCKeyedDecodingContainer(value: self.value, codingPath: self.codingPath, userInfo: self.userInfo)
     }
 
 	func container<Key>(keyedBy type: Key.Type) throws -> KeyedDecodingContainer<Key> where Key : CodingKey {
-		return KeyedDecodingContainer(try XPCKeyedDecodingContainer(value: self.value, codingPath: self.codingPath))
+        KeyedDecodingContainer(try XPCKeyedDecodingContainer(value: self.value,
+                                                             codingPath: self.codingPath,
+                                                             userInfo: self.userInfo))
 	}
 
 	func unkeyedContainer() throws -> UnkeyedDecodingContainer {
-        return try XPCUnkeyedDecodingContainer.containerFor(value: self.value, codingPath: self.codingPath)
+        try XPCUnkeyedDecodingContainer.containerFor(value: self.value,
+                                                     codingPath: self.codingPath,
+                                                     userInfo: self.userInfo)
 	}
 
 	func singleValueContainer() throws -> SingleValueDecodingContainer {
-		return XPCSingleValueDecodingContainer(value: self.value, codingPath: self.codingPath)
+        XPCSingleValueDecodingContainer(value: self.value,
+                                        codingPath: self.codingPath,
+                                        userInfo: self.userInfo)
 	}
 }

--- a/Sources/SecureXPC/XPC Coders/XPCDecoder/XPCSingleValueDecodingContainer.swift
+++ b/Sources/SecureXPC/XPC Coders/XPCDecoder/XPCSingleValueDecodingContainer.swift
@@ -9,14 +9,16 @@ import Foundation
 
 internal class XPCSingleValueDecodingContainer: SingleValueDecodingContainer {
 	var codingPath: [CodingKey] = []
+    let userInfo: [CodingUserInfoKey : Any]
 
 	private let value: xpc_object_t
 	private let type: xpc_type_t
 
-	init(value: xpc_object_t, codingPath: [CodingKey]) {
+    init(value: xpc_object_t, codingPath: [CodingKey], userInfo: [CodingUserInfoKey : Any]) {
 		self.value = value
 		self.type = xpc_get_type(value)
 		self.codingPath = codingPath
+        self.userInfo = userInfo
 	}
 
 	func decodeNil() -> Bool {
@@ -96,6 +98,8 @@ internal class XPCSingleValueDecodingContainer: SingleValueDecodingContainer {
 	}
 
 	func decode<T>(_ type: T.Type) throws -> T where T : Decodable {
-		return try type.init(from: XPCDecoderImpl(value: self.value, codingPath: self.codingPath))
+		return try type.init(from: XPCDecoderImpl(value: self.value,
+                                                  codingPath: self.codingPath,
+                                                  userInfo: self.userInfo))
 	}
 }

--- a/Sources/SecureXPC/XPCError.swift
+++ b/Sources/SecureXPC/XPCError.swift
@@ -54,9 +54,10 @@ public enum XPCError: Error, Codable {
     ///
     /// The associated string is a descriptive error message.
     case misconfiguredXPCService(String)
-    /// An error occurred that is not part of this framework, for example an error thrown by a handler registered with a ``XPCServer`` route. The associated
-    /// value describes the error.
-    case other(String)
+    /// An error thrown by a handler registered with a ``XPCServer`` route when processing a client's request.
+    ///
+    /// The associated value represents, and possibly contains, the error.
+    case handlerError(HandlerError)
     /// Unknown error occurred.
     case unknown
     
@@ -64,18 +65,16 @@ public enum XPCError: Error, Codable {
     ///
     /// - Parameters:
     ///   - error: The error to be represented as an ``XPCError``
-    ///   - expectingNonXPCError: Whether an error which is not an ``XPCError``, `DecodingError`, or `EncodingError` is expected. If it is,
-    ///   then its description will be returned as ``XPCError/other(_:)``, otherwise ``XPCError/unknown`` will be returned.
     /// - Returns: An ``XPCError`` to represent the passed in `error`
-    internal static func asXPCError(error: Error, expectingOtherError: Bool) -> XPCError {
+    internal static func asXPCError(error: Error) -> XPCError {
         if let error = error as? XPCError {
             return error
+        } else if let error = error as? HandlerError {
+            return .handlerError(error)
         } else if let error = error as? DecodingError {
             return .decodingError(String(describing: error))
         } else if let error = error as? EncodingError {
             return .encodingError(String(describing: error))
-        } else if expectingOtherError {
-            return .other(String(describing: error))
         } else {
             return .unknown
         }

--- a/Tests/SecureXPCTests/Client & Server/Error Integration Tests.swift
+++ b/Tests/SecureXPCTests/Client & Server/Error Integration Tests.swift
@@ -1,0 +1,126 @@
+//
+//  Error Integration Tests.swift
+//  
+//
+//  Created by Josh Kaplan on 2022-02-06.
+//
+
+import Foundation
+import XCTest
+@testable import SecureXPC
+
+private enum ExampleError: Error, Codable, Equatable {
+    case twoOfAKind
+}
+
+private enum SampleError: Error, Codable {
+    case twoOfAKind
+}
+
+class ErrorIntegrationTests: XCTestCase {
+    
+    func testErrorRegistered_Async() async throws {
+        let failureRoute = XPCRoute.named("always", "throws")
+                                   .throwsType(ExampleError.self)
+        let server = XPCServer.makeAnonymous()
+        let client = XPCClient.forEndpoint(server.endpoint)
+        server.registerRoute(failureRoute) {
+            throw ExampleError.twoOfAKind
+        }
+        server.start()
+        
+        let errorExpectation = self.expectation(description: "\(ExampleError.twoOfAKind) thrown")
+
+        do {
+            try await client.send(route: failureRoute)
+            XCTFail("No error thrown")
+        } catch ExampleError.twoOfAKind {
+            errorExpectation.fulfill()
+        } catch {
+            XCTFail("Error of wrong type was thrown: \(type(of: error)).\(error.self)")
+        }
+        
+        await self.waitForExpectations(timeout: 1)
+    }
+    
+    func testErrorRegistered_Closure() throws {
+        let errorToThrow = ExampleError.twoOfAKind
+        let failureRoute = XPCRoute.named("always", "throws")
+                                   .throwsType(ExampleError.self)
+        let server = XPCServer.makeAnonymous()
+        let client = XPCClient.forEndpoint(server.endpoint)
+        server.registerRoute(failureRoute) {
+            throw errorToThrow
+        }
+        server.start()
+        
+        let errorExpectation = self.expectation(description: "\(errorToThrow) thrown as underlying error")
+
+        client.send(route: failureRoute) { result in
+            do {
+                try result.get()
+                XCTFail("No errorw thrown")
+            } catch XPCError.handlerError(let error) {
+                if let underlyingError = error.underlyingError as? ExampleError,
+                   underlyingError == errorToThrow {
+                    errorExpectation.fulfill()
+                } else {
+                    XCTFail("Unexpected underlying error: \(error)")
+                }
+            } catch {
+                XCTFail("Unexpected error: \(error)")
+            }
+        }
+        
+        self.waitForExpectations(timeout: 1)
+    }
+    
+    func testOverlappingErrorCasesRegistered_Async() async throws {
+        let failureRoute = XPCRoute.named("always", "throws")
+                                   .throwsType(ExampleError.self)
+                                   .throwsType(SampleError.self)
+        let server = XPCServer.makeAnonymous()
+        let client = XPCClient.forEndpoint(server.endpoint)
+        server.registerRoute(failureRoute) {
+            throw ExampleError.twoOfAKind
+        }
+        server.start()
+        
+        let errorExpectation = self.expectation(description: "\(ExampleError.twoOfAKind) thrown")
+
+        do {
+            try await client.send(route: failureRoute)
+            XCTFail("No errorw thrown")
+        } catch ExampleError.twoOfAKind {
+            errorExpectation.fulfill()
+        } catch {
+            XCTFail("Unexpected error was thrown: \(type(of: error)).\(error.self)")
+        }
+        
+        await self.waitForExpectations(timeout: 1)
+    }
+    
+    func testErrorNotRegistered_Async() async throws {
+        let failureRoute = XPCRoute.named("always", "throws")
+                                   .throwsType(SampleError.self)
+        let server = XPCServer.makeAnonymous()
+        let client = XPCClient.forEndpoint(server.endpoint)
+        server.registerRoute(failureRoute) {
+            throw ExampleError.twoOfAKind
+        }
+        server.start()
+        
+        let errorExpectation = self.expectation(description: "XPCError.handleError thrown")
+
+        do {
+            try await client.send(route: failureRoute)
+            XCTFail("No errorw thrown")
+        } catch XPCError.handlerError(_) {
+            errorExpectation.fulfill()
+        } catch {
+            XCTFail("Unexpected error was thrown: \(type(of: error)).\(error.self)")
+        }
+        
+        await self.waitForExpectations(timeout: 1)
+    }
+}

--- a/Tests/SecureXPCTests/Client & Server/Error Integration Tests.swift
+++ b/Tests/SecureXPCTests/Client & Server/Error Integration Tests.swift
@@ -29,18 +29,14 @@ class ErrorIntegrationTests: XCTestCase {
         }
         server.start()
         
-        let errorExpectation = self.expectation(description: "\(ExampleError.twoOfAKind) thrown")
-
         do {
             try await client.send(route: failureRoute)
             XCTFail("No error thrown")
         } catch ExampleError.twoOfAKind {
-            errorExpectation.fulfill()
+            // success
         } catch {
             XCTFail("Error of wrong type was thrown: \(type(of: error)).\(error.self)")
         }
-        
-        await self.waitForExpectations(timeout: 1)
     }
     
     func testErrorRegistered_Closure() throws {
@@ -59,10 +55,10 @@ class ErrorIntegrationTests: XCTestCase {
         client.send(route: failureRoute) { result in
             do {
                 try result.get()
-                XCTFail("No errorw thrown")
+                XCTFail("No error thrown")
             } catch XPCError.handlerError(let error) {
-                if let underlyingError = error.underlyingError as? ExampleError,
-                   underlyingError == errorToThrow {
+                if case let .available(underlyingError) = error.underlyingError,
+                   underlyingError as? ExampleError == errorToThrow {
                     errorExpectation.fulfill()
                 } else {
                     XCTFail("Unexpected underlying error: \(error)")
@@ -86,18 +82,14 @@ class ErrorIntegrationTests: XCTestCase {
         }
         server.start()
         
-        let errorExpectation = self.expectation(description: "\(ExampleError.twoOfAKind) thrown")
-
         do {
             try await client.send(route: failureRoute)
-            XCTFail("No errorw thrown")
+            XCTFail("No error thrown")
         } catch ExampleError.twoOfAKind {
-            errorExpectation.fulfill()
+            //success
         } catch {
             XCTFail("Unexpected error was thrown: \(type(of: error)).\(error.self)")
         }
-        
-        await self.waitForExpectations(timeout: 1)
     }
     
     func testErrorNotRegistered_Async() async throws {
@@ -110,17 +102,13 @@ class ErrorIntegrationTests: XCTestCase {
         }
         server.start()
         
-        let errorExpectation = self.expectation(description: "XPCError.handleError thrown")
-
         do {
             try await client.send(route: failureRoute)
-            XCTFail("No errorw thrown")
+            XCTFail("No error thrown")
         } catch XPCError.handlerError(_) {
-            errorExpectation.fulfill()
+            // success
         } catch {
             XCTFail("Unexpected error was thrown: \(type(of: error)).\(error.self)")
         }
-        
-        await self.waitForExpectations(timeout: 1)
     }
 }


### PR DESCRIPTION
Overview of changes:
 - `HandlerError` always represents the error thrown by a server's handler closure
     - `HandlerError` will unconditionally try to encode any thrown errors
     - `HandlerError` will always encode a localized description of the error
 - The decoder and associated classes now properly support the `userInfo` dictionary
 - `Response` knows which `XPCRoute` it was for and adds this route to the `userInfo` when decoding an error
 - When one of `XPCClient`'s `async` send functions is called if an error was thrown and could be decoded by the client then it will be directly rethrown (that is, `HandlerError` will not be thrown)
     - From an API user point of view this is most of the value of this entire PR; everything "just works"
 - Tests were added for this functionality; all tests new and preexisting pass