### PR TITLE
Adds `XPCRequestContext` which exposes client info to the server

### DIFF
--- a/Sources/SecureXPC/SecureXPC.docc/SecureXPC.md
+++ b/Sources/SecureXPC/SecureXPC.docc/SecureXPC.md
@@ -75,3 +75,6 @@ See ``XPCClient`` for more on how to retrieve a client and send requests.
 ### Errors
 - ``XPCError``
 - ``HandlerError``
+
+### Other
+- ``XPCRequestContext``

--- a/Sources/SecureXPC/Server/MessageAcceptor.swift
+++ b/Sources/SecureXPC/Server/MessageAcceptor.swift
@@ -47,62 +47,10 @@ internal struct SecureMessageAcceptor: MessageAcceptor {
     ///
     /// If the `SecCode` of the process belonging to the other side of the connection could be not be determined, `false` is always returned.
     func acceptMessage(connection: xpc_connection_t, message: xpc_object_t) -> Bool {
-        // Get the code representing the client
-        var code: SecCode?
-        if #available(macOS 11, *) { // publicly documented, but only available since macOS 11
-            SecCodeCreateWithXPCMessage(message, SecCSFlags(), &code)
-        } else { // private undocumented function: xpc_connection_get_audit_token, available on prior versions of macOS
-            let token = SecureMessageAcceptor.xpc_connection_get_audit_token(connection)
-            let tokenValues = [token.val.0, token.val.1, token.val.2, token.val.3,
-                               token.val.4, token.val.5, token.val.6, token.val.7]
-            let tokenData = Data(bytes: tokenValues, count: tokenValues.count * MemoryLayout<UInt32>.size)
-            let attributes = [kSecGuestAttributeAudit : tokenData] as CFDictionary
-            SecCodeCopyGuestWithAttributes(nil, attributes, SecCSFlags(), &code)
-        }
-        guard let code = code else { // Instead of explicitly checking the return codes from the SecCode* function calls
+        guard let code = SecCodeCreateWithXPCConnection(connection, andMessage: message) else {
             return false
         }
         
         return self.requirements.contains { SecCodeCheckValidity(code, SecCSFlags(), $0) == errSecSuccess }
-    }
-    
-    // MARK: xpc_connection_get_audit_token
-    
-    /// The function signature of  `void xpc_connection_get_audit_token(xpc_connection_t, audit_token_t *)`.
-    private typealias get_audit_token = @convention(c) (xpc_connection_t, UnsafeMutablePointer<audit_token_t>) -> Void
-    
-    /// Represents the private undocumented function `void xpc_connection_get_audit_token(xpc_connection_t, audit_token_t *)`.
-    /// If the function does exist, but does not match the expected signature, then when this variable is loaded the process accessing this variable will crash.
-    /// However, this variable should only be access on older versions of macOS which are expected to have a stable non-changing API so this should not occur.
-    ///
-    /// If this function can't be loaded for some version, a fatalError will intentonally be raised as this should never occur on an older version of macOS supported by
-    /// SecureXPC.
-    ///
-    /// Note that because static variables are implicitly lazy the code to populate this variable never run unless this variable is accessed.
-    private static var xpc_connection_get_audit_tokenFunction: get_audit_token = {
-        // From man dlopen 3: If a null pointer is passed in path, dlopen() returns a handle equivalent to RTLD_DEFAULT
-        guard let handle = dlopen(nil, RTLD_LAZY) else {
-            fatalError("dlopen call to retrieve RTLD_DEFAULT unexpectedly failed, this should never happen")
-        }
-        defer { dlclose(handle) }
-        guard let sym = dlsym(handle, "xpc_connection_get_audit_token") else {
-            // Include macOS version number to assist in reproducing any reported issues
-            fatalError("Function xpc_connection_get_audit_token could not be loaded while running on " +
-                       ProcessInfo.processInfo.operatingSystemVersionString)
-        }
-        
-        return unsafeBitCast(sym, to: get_audit_token.self)
-    }()
-    
-    /// Wrapper around the private undocumented function `void xpc_connection_get_audit_token(xpc_connection_t, audit_token_t *)`.
-    ///
-    /// - Parameters:
-    ///   - _:  The connection for which the audit token will be retrieved for.
-    /// - Returns: The audit token.
-    private static func xpc_connection_get_audit_token(_ connection: xpc_connection_t) -> audit_token_t {
-        var token = audit_token_t()
-        xpc_connection_get_audit_tokenFunction(connection, &token)
-        
-        return token
     }
 }

--- a/Sources/SecureXPC/XPCCommon.swift
+++ b/Sources/SecureXPC/XPCCommon.swift
@@ -19,3 +19,65 @@ func const(_ input: UnsafePointer<CChar>!) -> UnsafePointer<CChar>! {
 	let mutableCopy = strdup(input)!
 	return UnsafePointer(mutableCopy) // The result should never actually be mutated
 }
+
+/// Determines the `SecCode` corresponding to an XPC connection and/or message.
+///
+/// Uses undocumented functionality prior to macOS 11.
+func SecCodeCreateWithXPCConnection(_ connection: xpc_connection_t, andMessage message: xpc_object_t) -> SecCode? {
+    // Get the code representing the client
+    var code: SecCode?
+    if #available(macOS 11, *) { // publicly documented, but only available since macOS 11
+        SecCodeCreateWithXPCMessage(message, SecCSFlags(), &code)
+    } else { // private undocumented function: xpc_connection_get_audit_token, available on prior versions of macOS
+        let token = UndocumentedAuditToken.xpc_connection_get_audit_token(connection)
+        let tokenValues = [token.val.0, token.val.1, token.val.2, token.val.3,
+                           token.val.4, token.val.5, token.val.6, token.val.7]
+        let tokenData = Data(bytes: tokenValues, count: tokenValues.count * MemoryLayout<UInt32>.size)
+        let attributes = [kSecGuestAttributeAudit : tokenData] as CFDictionary
+        SecCodeCopyGuestWithAttributes(nil, attributes, SecCSFlags(), &code)
+    }
+    
+    return code
+}
+
+/// Encapsulates the undocumented function `void xpc_connection_get_audit_token(xpc_connection_t, audit_token_t *)`.
+fileprivate struct UndocumentedAuditToken {
+    
+    /// The function signature of  `void xpc_connection_get_audit_token(xpc_connection_t, audit_token_t *)`.
+    private typealias get_audit_token = @convention(c) (xpc_connection_t, UnsafeMutablePointer<audit_token_t>) -> Void
+    
+    /// Represents the private undocumented function `void xpc_connection_get_audit_token(xpc_connection_t, audit_token_t *)`.
+    /// If the function does exist, but does not match the expected signature, then when this variable is loaded the process accessing this variable will crash.
+    /// However, this variable should only be access on older versions of macOS which are expected to have a stable non-changing API so this should not occur.
+    ///
+    /// If this function can't be loaded for some version, a fatalError will intentonally be raised as this should never occur on an older version of macOS supported by
+    /// SecureXPC.
+    ///
+    /// Note that because static variables are implicitly lazy the code to populate this variable never run unless this variable is accessed.
+    private static var xpc_connection_get_audit_tokenFunction: get_audit_token = {
+        // From man dlopen 3: If a null pointer is passed in path, dlopen() returns a handle equivalent to RTLD_DEFAULT
+        guard let handle = dlopen(nil, RTLD_LAZY) else {
+            fatalError("dlopen call to retrieve RTLD_DEFAULT unexpectedly failed, this should never happen")
+        }
+        defer { dlclose(handle) }
+        guard let sym = dlsym(handle, "xpc_connection_get_audit_token") else {
+            // Include macOS version number to assist in reproducing any reported issues
+            fatalError("Function xpc_connection_get_audit_token could not be loaded while running on " +
+                       ProcessInfo.processInfo.operatingSystemVersionString)
+        }
+        
+        return unsafeBitCast(sym, to: get_audit_token.self)
+    }()
+    
+    /// Wrapper around the private undocumented function `void xpc_connection_get_audit_token(xpc_connection_t, audit_token_t *)`.
+    ///
+    /// - Parameters:
+    ///   - _:  The connection for which the audit token will be retrieved for.
+    /// - Returns: The audit token.
+    fileprivate static func xpc_connection_get_audit_token(_ connection: xpc_connection_t) -> audit_token_t {
+        var token = audit_token_t()
+        xpc_connection_get_audit_tokenFunction(connection, &token)
+        
+        return token
+    }
+}

--- a/Sources/SecureXPC/XPCRequestContext.swift
+++ b/Sources/SecureXPC/XPCRequestContext.swift
@@ -14,8 +14,8 @@ import Foundation
 /// ## Topics
 /// ### Client Information
 /// - ``clientCode``
-/// - ``effectiveUserId``
-/// - ``effectiveGroupId``
+/// - ``effectiveUserID``
+/// - ``effectiveGroupID``
 public class XPCRequestContext {
     private let connection: xpc_connection_t
     private let message: xpc_object_t
@@ -26,7 +26,7 @@ public class XPCRequestContext {
     }
     
     // MARK: task local
-        
+    
     @available(macOS 10.15.0, *)
     @TaskLocal
     private static var currentForTask: XPCRequestContext?
@@ -77,12 +77,12 @@ public class XPCRequestContext {
     // readily result in security vulnerabilities
     
     /// The effective user id of the client process.
-    public static var effectiveUserId: uid_t {
+    public static var effectiveUserID: uid_t {
         xpc_connection_get_euid(current.connection)
     }
     
     /// The effective group id of the client process.
-    public static var effectiveGroupId: gid_t {
+    public static var effectiveGroupID: gid_t {
         xpc_connection_get_egid(current.connection)
     }
     

--- a/Sources/SecureXPC/XPCRequestContext.swift
+++ b/Sources/SecureXPC/XPCRequestContext.swift
@@ -1,0 +1,93 @@
+//
+//  XPCRequestContext.swift
+//  SecureXPC
+//
+//  Created by Josh Kaplan on 2022-02-22.
+//
+
+import Foundation
+
+/// Provides information about the current request being handled by an ``XPCServer``.
+///
+/// Accessing the properties exposed by this class is a programming error unless called from inside of a closure registered with and called by an `XPCServer`.
+///
+/// ## Topics
+/// ### Client Information
+/// - ``clientCode``
+/// - ``effectiveUserId``
+/// - ``effectiveGroupId``
+public class XPCRequestContext {
+    private let connection: xpc_connection_t
+    private let message: xpc_object_t
+    
+    private init(connection: xpc_connection_t, message: xpc_object_t) {
+        self.connection = connection
+        self.message = message
+    }
+    
+    // MARK: task local
+        
+    @available(macOS 10.15.0, *)
+    @TaskLocal
+    private static var currentForTask: XPCRequestContext?
+    
+    @available(macOS 10.15.0, *)
+    @discardableResult internal static func setForTask<Success, Failure>(
+        connection: xpc_connection_t,
+        message: xpc_object_t,
+        operation: () throws -> Task<Success, Failure>
+    ) rethrows -> Task<Success, Failure> {
+        try $currentForTask.withValue(XPCRequestContext(connection: connection, message: message)) {
+            try operation()
+        }
+    }
+    
+    // MARK: thread local
+    
+    private static let contextKey = UUID()
+    
+    @discardableResult internal static func setForCurrentThread<R>(
+        connection: xpc_connection_t,
+        message: xpc_object_t,
+        operation: () throws -> R
+    ) rethrows -> R {
+        Thread.current.threadDictionary[contextKey] = XPCRequestContext(connection: connection, message: message)
+        let result = try operation()
+        Thread.current.threadDictionary.removeObject(forKey: contextKey)
+        
+        return result
+    }
+    
+    // MARK: current context
+    
+    private static var current: XPCRequestContext {
+        if let current = Thread.current.threadDictionary[contextKey] as? XPCRequestContext {
+            return current
+        } else if #available(macOS 10.15.0, *), let current = currentForTask {
+            return current
+        } else {
+            fatalError("\(XPCRequestContext.self) can only be accessed from within the thread or task of a closure " +
+                       "called by \(XPCServer.self).")
+        }
+    }
+    
+    // MARK: public functions
+    
+    // It's intentional that the process id (PID) of the client process is not exposed since misuse of this can
+    // readily result in security vulnerabilities
+    
+    /// The effective user id of the client process.
+    public static var effectiveUserId: uid_t {
+        xpc_connection_get_euid(current.connection)
+    }
+    
+    /// The effective group id of the client process.
+    public static var effectiveGroupId: gid_t {
+        xpc_connection_get_egid(current.connection)
+    }
+    
+    /// A represention of the client process.
+    public static var clientCode: SecCode? {
+        SecCodeCreateWithXPCConnection(current.connection, andMessage: current.message)
+    }
+}

--- a/Tests/SecureXPCTests/Client & Server/XPCRequestContext Tests.swift
+++ b/Tests/SecureXPCTests/Client & Server/XPCRequestContext Tests.swift
@@ -1,0 +1,131 @@
+//
+//  XPCRequestContextTest.swift
+//  
+//
+//  Created by Josh Kaplan on 2022-02-23.
+//
+
+import Foundation
+import XCTest
+import SecureXPC
+
+class XPCRequestContextTest: XCTestCase {
+    
+    func testGetEffectiveUserId_async() async throws {
+        let route = XPCRoute.named("does", "nothing")
+        let server = XPCServer.makeAnonymous()
+        let client = XPCClient.forEndpoint(server.endpoint)
+        
+        server.registerRoute(route) { () async -> Void in
+            // If this fails it'll fatalError, so all we're doing here is ensuring that doesn't happen
+            _ = XPCRequestContext.effectiveUserId
+        }
+        server.start()
+        
+        try await client.send(route: route)
+    }
+    
+    func testGetEffectiveUserId_sync() throws {
+        let route = XPCRoute.named("does", "nothing")
+        let server = XPCServer.makeAnonymous()
+        let client = XPCClient.forEndpoint(server.endpoint)
+        
+        let contextValueAccessed = self.expectation(description: "Able to access effective user id")
+        
+        server.registerRoute(route) {
+            // If this fails it'll fatalError, so all we're doing here is ensuring that doesn't happen
+            _ = XPCRequestContext.effectiveUserId
+            contextValueAccessed.fulfill()
+        }
+        server.start()
+        
+        client.send(route: route, onCompletion: nil)
+        
+        self.waitForExpectations(timeout: 1)
+    }
+    
+    func testGetEffectiveGroupId_async() async throws {
+        let route = XPCRoute.named("does", "nothing")
+        let server = XPCServer.makeAnonymous()
+        let client = XPCClient.forEndpoint(server.endpoint)
+        
+        server.registerRoute(route) { () async -> Void in
+            XCTAssertNotNil(XPCRequestContext.effectiveGroupId)
+        }
+        server.start()
+        
+        try await client.send(route: route)
+    }
+    
+    func testGetEffectiveGroupId_sync() throws {
+        let route = XPCRoute.named("does", "nothing")
+        let server = XPCServer.makeAnonymous()
+        let client = XPCClient.forEndpoint(server.endpoint)
+        
+        let contextValueAccessed = self.expectation(description: "Able to access effective group id")
+        
+        server.registerRoute(route) {
+            // If this fails it'll fatalError, so all we're doing here is ensuring that doesn't happen
+            _ = XPCRequestContext.effectiveGroupId
+            contextValueAccessed.fulfill()
+        }
+        server.start()
+        
+        client.send(route: route, onCompletion: nil)
+        
+        self.waitForExpectations(timeout: 1)
+    }
+    
+    func testGetClientCode_async() async throws {
+        let route = XPCRoute.named("does", "nothing")
+        let server = XPCServer.makeAnonymous()
+        let client = XPCClient.forEndpoint(server.endpoint)
+        
+        server.registerRoute(route) { () async -> Void in
+            XCTAssertNotNil(XPCRequestContext.clientCode)
+            var staticCode: SecStaticCode?
+            SecCodeCopyStaticCode(XPCRequestContext.clientCode!, [], &staticCode)
+            var signingInfo: CFDictionary?
+            SecCodeCopySigningInformation(staticCode!, [], &signingInfo)
+            if let signingInfo = signingInfo as NSDictionary?,
+               signingInfo[kSecCodeInfoIdentifier] as? String == "com.apple.xctest" {
+                // success
+                return
+            } else {
+                XCTFail("wrong identifier")
+            }
+        }
+        server.start()
+        
+        try await client.send(route: route)
+    }
+    
+    func testGetClientCode_sync() throws {
+        let route = XPCRoute.named("does", "nothing")
+        let server = XPCServer.makeAnonymous()
+        let client = XPCClient.forEndpoint(server.endpoint)
+        
+        let clientCodeNotNil = self.expectation(description: "Client code should not be nil in this circumstance")
+        let xctestIdentifier = self.expectation(description: "Client code's identifier should be com.apple.xctest")
+        
+        server.registerRoute(route) {
+            if let clientCode = XPCRequestContext.clientCode {
+                clientCodeNotNil.fulfill()
+                var staticCode: SecStaticCode?
+                SecCodeCopyStaticCode(clientCode, [], &staticCode)
+                var signingInfo: CFDictionary?
+                SecCodeCopySigningInformation(staticCode!, [], &signingInfo)
+                if let signingInfo = signingInfo as NSDictionary?,
+                   signingInfo[kSecCodeInfoIdentifier] as? String == "com.apple.xctest" {
+                    xctestIdentifier.fulfill()
+                }
+            }
+            
+        }
+        server.start()
+        
+        client.send(route: route, onCompletion: nil)
+        
+        self.waitForExpectations(timeout: 1)
+    }
+}


### PR DESCRIPTION
The core addition here is the introduction of the entirely optional `XPCRequestContext` which has static properties that are accessible within the execution context of a closure called by `XPCServer`.

The motivation behind this PR is that there are times where I need to differ the behavior of the server based on the caller. Since I trust all of my clients I could have them explicitly provide this information, but it seemed more robust to have this be determined server side.

The design is a bit "magic" so I'm torn on it. I considered three different approaches and ultimately settled on this one. The other two considered were:
1. Closures registered with the server *must* have `XPCRequestContext` as a parameter.
2. Closures registered with the server *may* have `XPCRequestContext` as a parameter.

Approach 1 felt far too heavy handed as I don't think the average user of SecureXPC will need to make use of `XPCRequestContext`. Approach 2 would require doubling the number of handler registration functions from 8 to 16 along with all of the associated boiler plate. Additionally it'd make `XPCRequestContext` more prominent in the API and that's undesirable as again I think it'll be needed in a small minority of cases.