### PR TITLE
Documentation improvements to consistently use "request" terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 Use pure Swift to easily and securely communicate with XPC services and XPC Mach services. A client-server model 
 enables you to use your own [`Codable`](https://developer.apple.com/documentation/swift/codable) conforming types to
-send messages to routes you define and receive replies. 
+send requests to routes you define and receive responses. 
 
 SecureXPC uses [Swift concurrency](https://docs.swift.org/swift-book/LanguageGuide/Concurrency.html) on macOS 10.15 and
-later allowing clients to make non-blocking asynchronous calls to servers. A closure-based API is also available
+later allowing clients to make non-blocking asynchronous requests to servers. A closure-based API is also available
 providing compatibility back to OS X 10.10.
 
 This framework is ideal for communicating with helper tools installed via 
@@ -17,8 +17,8 @@ against the actual calling process instead of relying on PIDs which are known to
 
 # Usage
 The envisioned pattern when using this framework is to define routes in a shared file, create a server in one program
-(such as a helper tool) and register these routes, then from another program (such as an app) create a client and call
-these routes.
+(such as a helper tool) and register these routes, then from another program (such as an app) create a client and send
+requests to these routes.
 
 ## Routes
 In a file shared by the client and server define one or more routes:
@@ -62,7 +62,7 @@ There are multiple types of servers which can be retrieved:
      - Enables applications not managed by `launchd` to communicate with each other, see documentation for more details
 
 ## Client
-In another program retrieve a client, then call one of the registered routes:
+In another program retrieve a client, then send a request to a registered route:
 ```swift
 let client = <# client retrieval here #>
 let reply = try await client.sendMessage("Get Schwifty", route: route)

--- a/Sources/SecureXPC/SecureXPC.docc/SecureXPC.md
+++ b/Sources/SecureXPC/SecureXPC.docc/SecureXPC.md
@@ -12,8 +12,8 @@ Mach service. Customized support for communicating with helper tools installed v
 
 ## Usage
 The envisioned pattern when using this framework is to define routes in a shared file, retrieve a server in one program
-(such as a helper tool) and register these routes, then from another program (such as an app) retrieve a client and call
-these routes.
+(such as a helper tool) and register these routes, then from another program (such as an app) retrieve a client and send
+requests to these routes.
 
 #### Routes
 
@@ -44,7 +44,7 @@ See ``XPCServer`` for details on how to retrieve, configure, and start a server.
 
 #### Client
 
-In another program retrieve a client, then call one of those routes:
+In another program retrieve a client, then send a request to one of these routes:
 ```swift
 let client = <# client retrieval here #>
 try client.sendMessage("Get Schwifty", route: route, withResponse: { response in

--- a/Sources/SecureXPC/Server/XPCServer.swift
+++ b/Sources/SecureXPC/Server/XPCServer.swift
@@ -79,16 +79,16 @@ import Foundation
 /// - ``forThisMachService(named:clientRequirements:)``
 /// - ``makeAnonymous()``
 /// - ``makeAnonymous(clientRequirements:)``
-/// ### Registering Routes
-/// - ``registerRoute(_:handler:)-4ttqe``
-/// - ``registerRoute(_:handler:)-9a0x9``
-/// - ``registerRoute(_:handler:)-4fxv0``
-/// - ``registerRoute(_:handler:)-1jw9d``
 /// ### Registering Async Routes
 /// - ``registerRoute(_:handler:)-6htah``
 /// - ``registerRoute(_:handler:)-g7ww``
 /// - ``registerRoute(_:handler:)-rw2w``
 /// - ``registerRoute(_:handler:)-2vk6u``
+/// ### Registering Synchronous Routes
+/// - ``registerRoute(_:handler:)-4ttqe``
+/// - ``registerRoute(_:handler:)-9a0x9``
+/// - ``registerRoute(_:handler:)-4fxv0``
+/// - ``registerRoute(_:handler:)-1jw9d``
 /// ### Configuring a Server
 /// - ``targetQueue``
 /// - ``setErrorHandler(_:)-lex4``
@@ -152,8 +152,8 @@ public class XPCServer {
             fatalError("Route \(route.pathComponents) is already registered")
         }
     }
-    
-    /// Registers a route that has no message and can't receive a reply.
+        
+    /// Registers a route for a request without a message that does not receive a reply.
     ///
     /// > Important: Routes can only be registered with a handler once; it is a programming error to provide a route which has already been registered.
     ///
@@ -165,7 +165,7 @@ public class XPCServer {
         self.registerRoute(route.route, handler: ConstrainedXPCHandlerWithoutMessageWithoutReplySync(handler: handler))
     }
     
-    /// Registers a route that has no message and can't receive a reply.
+    /// Registers a route for a request without a message that does not receive a reply.
     ///
     /// > Important: Routes can only be registered with a handler once; it is a programming error to provide a route which has already been registered.
     ///
@@ -178,7 +178,7 @@ public class XPCServer {
         self.registerRoute(route.route, handler: ConstrainedXPCHandlerWithoutMessageWithoutReplyAsync(handler: handler))
     }
     
-    /// Registers a route that has a message and can't receive a reply.
+    /// Registers a route for a request with a message that does not receive a reply.
     ///
     /// > Important: Routes can only be registered with a handler once; it is a programming error to provide a route which has already been registered.
     ///
@@ -190,7 +190,7 @@ public class XPCServer {
         self.registerRoute(route.route, handler: ConstrainedXPCHandlerWithMessageWithoutReplySync(handler: handler))
     }
     
-    /// Registers a route that has a message and can't receive a reply.
+    /// Registers a route for a request with a message that does not receive a reply.
     ///
     /// > Important: Routes can only be registered with a handler once; it is a programming error to provide a route which has already been registered.
     ///
@@ -203,7 +203,7 @@ public class XPCServer {
         self.registerRoute(route.route, handler: ConstrainedXPCHandlerWithMessageWithoutReplyAsync(handler: handler))
     }
     
-    /// Registers a route that has no message and expects a reply.
+    /// Registers a route for a request without a message that receives a reply.
     ///
     /// > Important: Routes can only be registered with a handler once; it is a programming error to provide a route which has already been registered.
     ///
@@ -215,7 +215,7 @@ public class XPCServer {
         self.registerRoute(route.route, handler: ConstrainedXPCHandlerWithoutMessageWithReplySync(handler: handler))
     }
     
-    /// Registers a route that has no message and expects a reply.
+    /// Registers a route for a request without a message that receives a reply.
     ///
     /// > Important: Routes can only be registered with a handler once; it is a programming error to provide a route which has already been registered.
     ///
@@ -228,7 +228,7 @@ public class XPCServer {
         self.registerRoute(route.route, handler: ConstrainedXPCHandlerWithoutMessageWithReplyAsync(handler: handler))
     }
     
-    /// Registers a route that has a message and expects a reply.
+    /// Registers a route for a request with a message that receives a reply.
     ///
     /// > Important: Routes can only be registered with a handler once; it is a programming error to provide a route which has already been registered.
     ///
@@ -240,7 +240,7 @@ public class XPCServer {
         self.registerRoute(route.route, handler: ConstrainedXPCHandlerWithMessageWithReplySync(handler: handler))
     }
     
-    /// Registers a route that has a message and expects a reply.
+    /// Registers a route for a request with a message that receives a reply.
     ///
     /// > Important: Routes can only be registered with a handler once; it is a programming error to provide a route which has already been registered.
     ///

--- a/Sources/SecureXPC/XPCError.swift
+++ b/Sources/SecureXPC/XPCError.swift
@@ -34,9 +34,9 @@ public enum XPCError: Error, Codable {
     ///
     /// The associated value describes this decoding error.
     case decodingError(String)
-    /// The route associated with the incoming XPC request is not registered with the ``XPCServer``.
+    /// The route associated with the incoming request is not registered with the ``XPCServer``.
     case routeNotRegistered([String])
-    /// While the route associated with the incoming XPC request is registered with the ``XPCServer``, the message and/or reply does not match the handler
+    /// While the route associated with the incoming request is registered with the ``XPCServer``, the message and/or reply does not match the handler
     /// registered with the server.
     ///
     /// The first associated value is the route's path components. The second is a descriptive error message.


### PR DESCRIPTION
The documentation should now always say that what's being sent is a request, regardless of whether there's a message or not.

This PR contains no code changes, only documentation changes.