### PR TITLE
Renames `route` parameter to `toRoute` for `send` functions

### DIFF
--- a/Sources/SecureXPC/SecureXPC.docc/SecureXPC.md
+++ b/Sources/SecureXPC/SecureXPC.docc/SecureXPC.md
@@ -47,7 +47,7 @@ See ``XPCServer`` for details on how to retrieve, configure, and start a server.
 In another program retrieve a client, then send a request to one of these routes:
 ```swift
 let client = <# client retrieval here #>
-try client.sendMessage("Get Schwifty", route: route, withResponse: { response in
+try client.sendMessage("Get Schwifty", toRoute: route, withResponse: { response in
     switch response {
         case .success(let reply):
             <# use the reply #>

--- a/Tests/SecureXPCTests/Client & Server/Error Integration Tests.swift
+++ b/Tests/SecureXPCTests/Client & Server/Error Integration Tests.swift
@@ -30,7 +30,7 @@ class ErrorIntegrationTests: XCTestCase {
         server.start()
         
         do {
-            try await client.send(route: failureRoute)
+            try await client.send(toRoute: failureRoute)
             XCTFail("No error thrown")
         } catch ExampleError.twoOfAKind {
             // success
@@ -52,7 +52,7 @@ class ErrorIntegrationTests: XCTestCase {
         
         let errorExpectation = self.expectation(description: "\(errorToThrow) thrown as underlying error")
 
-        client.send(route: failureRoute) { result in
+        client.send(toRoute: failureRoute) { result in
             do {
                 try result.get()
                 XCTFail("No error thrown")
@@ -83,7 +83,7 @@ class ErrorIntegrationTests: XCTestCase {
         server.start()
         
         do {
-            try await client.send(route: failureRoute)
+            try await client.send(toRoute: failureRoute)
             XCTFail("No error thrown")
         } catch ExampleError.twoOfAKind {
             //success
@@ -103,7 +103,7 @@ class ErrorIntegrationTests: XCTestCase {
         server.start()
         
         do {
-            try await client.send(route: failureRoute)
+            try await client.send(toRoute: failureRoute)
             XCTFail("No error thrown")
         } catch XPCError.handlerError(_) {
             // success

--- a/Tests/SecureXPCTests/Client & Server/Round-trip Integration Test.swift
+++ b/Tests/SecureXPCTests/Client & Server/Round-trip Integration Test.swift
@@ -30,7 +30,7 @@ class RoundTripIntegrationTest: XCTestCase {
             return "echo: \(msg)"
         }
 
-        self.xpcClient.sendMessage("Hello, world!", route: echoRoute) { result in
+        self.xpcClient.sendMessage("Hello, world!", toRoute: echoRoute) { result in
             XCTAssertNoThrow {
                 let response = try result.get()
                 XCTAssertEqual(response, "echo: Hello, world!")
@@ -45,7 +45,7 @@ class RoundTripIntegrationTest: XCTestCase {
     func testSendWithMessageWithReply_AsyncClient_SyncServer() async throws {
         let echoRoute = XPCRoute.named("echo").withMessageType(String.self).withReplyType(String.self)
         anonymousServer.registerRoute(echoRoute) { msg in "echo: \(msg)" }
-        let result = try await xpcClient.sendMessage("Hello, world!", route: echoRoute)
+        let result = try await xpcClient.sendMessage("Hello, world!", toRoute: echoRoute)
         XCTAssertEqual(result, "echo: Hello, world!")
     }
     
@@ -54,7 +54,7 @@ class RoundTripIntegrationTest: XCTestCase {
         anonymousServer.registerRoute(echoRoute) { (msg: String) async -> String in
             "echo: \(msg)"
         }
-        let result = try await xpcClient.sendMessage("Hello, world!", route: echoRoute)
+        let result = try await xpcClient.sendMessage("Hello, world!", toRoute: echoRoute)
         XCTAssertEqual(result, "echo: Hello, world!")
     }
 
@@ -68,7 +68,7 @@ class RoundTripIntegrationTest: XCTestCase {
             return "pong"
         }
 
-        self.xpcClient.send(route: pingRoute) { result in
+        self.xpcClient.send(toRoute: pingRoute) { result in
             XCTAssertNoThrow {
                 let response = try result.get()
                 XCTAssertEqual(response, "pong")
@@ -83,7 +83,7 @@ class RoundTripIntegrationTest: XCTestCase {
     func testSendWithoutMessageWithReply_AsyncClient_SyncServer() async throws {
         let pingRoute = XPCRoute.named("ping").withReplyType(String.self)
         anonymousServer.registerRoute(pingRoute) { "pong" }
-        let result = try await xpcClient.send(route: pingRoute)
+        let result = try await xpcClient.send(toRoute: pingRoute)
         XCTAssertEqual(result, "pong")
     }
     
@@ -92,7 +92,7 @@ class RoundTripIntegrationTest: XCTestCase {
         anonymousServer.registerRoute(pingRoute) { () async -> String in
             "pong"
         }
-        let result = try await xpcClient.send(route: pingRoute)
+        let result = try await xpcClient.send(toRoute: pingRoute)
         XCTAssertEqual(result, "pong")
     }
 
@@ -105,7 +105,7 @@ class RoundTripIntegrationTest: XCTestCase {
             remoteHandlerWasCalled.fulfill()
         }
 
-        self.xpcClient.sendMessage("Hello, world!", route: msgNoReplyRoute, onCompletion: nil)
+        self.xpcClient.sendMessage("Hello, world!", toRoute: msgNoReplyRoute, onCompletion: nil)
 
         self.waitForExpectations(timeout: 1)
     }
@@ -120,7 +120,7 @@ class RoundTripIntegrationTest: XCTestCase {
             remoteHandlerWasCalled.fulfill()
         }
 
-        self.xpcClient.sendMessage("Hello, world!", route: msgNoReplyRoute) { response in
+        self.xpcClient.sendMessage("Hello, world!", toRoute: msgNoReplyRoute) { response in
             responseBlockWasCalled.fulfill()
             XCTAssertNoThrow {
                 try response.get()
@@ -137,7 +137,7 @@ class RoundTripIntegrationTest: XCTestCase {
             XCTAssertEqual(msg, "Hello, world!")
             remoteHandlerWasCalled.fulfill()
         }
-        try await xpcClient.sendMessage("Hello, world!", route: msgNoReplyRoute)
+        try await xpcClient.sendMessage("Hello, world!", toRoute: msgNoReplyRoute)
         
         await self.waitForExpectations(timeout: 1)
     }
@@ -149,7 +149,7 @@ class RoundTripIntegrationTest: XCTestCase {
             XCTAssertEqual(msg, "Hello, world!")
             remoteHandlerWasCalled.fulfill()
         }
-        try await xpcClient.sendMessage("Hello, world!", route: msgNoReplyRoute)
+        try await xpcClient.sendMessage("Hello, world!", toRoute: msgNoReplyRoute)
         
         await self.waitForExpectations(timeout: 1)
     }
@@ -162,7 +162,7 @@ class RoundTripIntegrationTest: XCTestCase {
             remoteHandlerWasCalled.fulfill()
         }
 
-        self.xpcClient.send(route: noMsgNoReplyRoute, onCompletion: nil)
+        self.xpcClient.send(toRoute: noMsgNoReplyRoute, onCompletion: nil)
 
         self.waitForExpectations(timeout: 1)
     }
@@ -176,7 +176,7 @@ class RoundTripIntegrationTest: XCTestCase {
             remoteHandlerWasCalled.fulfill()
         }
 
-        self.xpcClient.send(route: noMsgNoReplyRoute) { response in
+        self.xpcClient.send(toRoute: noMsgNoReplyRoute) { response in
             responseBlockWasCalled.fulfill()
             XCTAssertNoThrow {
                 try response.get()
@@ -192,7 +192,7 @@ class RoundTripIntegrationTest: XCTestCase {
         anonymousServer.registerRoute(noMsgNoReplyRoute) {
             remoteHandlerWasCalled.fulfill()
         }
-        try await xpcClient.send(route: noMsgNoReplyRoute)
+        try await xpcClient.send(toRoute: noMsgNoReplyRoute)
         
         await self.waitForExpectations(timeout: 1)
     }
@@ -203,7 +203,7 @@ class RoundTripIntegrationTest: XCTestCase {
         anonymousServer.registerRoute(noMsgNoReplyRoute, handler: { () async -> Void in
             remoteHandlerWasCalled.fulfill()
         })
-        try await xpcClient.send(route: noMsgNoReplyRoute)
+        try await xpcClient.send(toRoute: noMsgNoReplyRoute)
         
         await self.waitForExpectations(timeout: 1)
     }

--- a/Tests/SecureXPCTests/Client & Server/Server Error Handler Test.swift
+++ b/Tests/SecureXPCTests/Client & Server/Server Error Handler Test.swift
@@ -42,7 +42,7 @@ class ServerErrorHandlerTest: XCTestCase {
         
         server.start()
         
-        client.send(route: failureRoute, onCompletion: nil)
+        client.send(toRoute: failureRoute, onCompletion: nil)
         
         self.waitForExpectations(timeout: 1)
     }
@@ -73,7 +73,7 @@ class ServerErrorHandlerTest: XCTestCase {
         
         server.start()
         
-        client.send(route: failureRoute, onCompletion: nil)
+        client.send(toRoute: failureRoute, onCompletion: nil)
         
         self.waitForExpectations(timeout: 1)
     }

--- a/Tests/SecureXPCTests/Client & Server/Server Termination Integration Test.swift
+++ b/Tests/SecureXPCTests/Client & Server/Server Termination Integration Test.swift
@@ -28,14 +28,14 @@ class ServerTerminationIntegrationTest: XCTestCase {
         let client = XPCClient.forEndpoint(server.endpoint)
         
         // Send a message, which will result in the connection being established with the server
-        try await client.send(route: route)
+        try await client.send(toRoute: route)
         
         // Shut down the server, simulating the scenario of the process containing the server terminating
         (server as! XPCAnonymousServer).simulateDisconnectionForTesting()
         
         let interruptedExpectation = self.expectation(description: "Second message results in an interrupted error")
         do {
-            try await client.send(route: route)
+            try await client.send(toRoute: route)
         } catch {
             switch error {
                 case XPCError.connectionInterrupted:
@@ -47,7 +47,7 @@ class ServerTerminationIntegrationTest: XCTestCase {
         
         let cannotBeReestablishedExpectation = self.expectation(description: "Third message can't establish connection")
         do {
-            try await client.send(route: route)
+            try await client.send(toRoute: route)
         } catch {
             switch error {
                 case XPCError.connectionCannotBeReestablished:

--- a/Tests/SecureXPCTests/Client & Server/XPCRequestContext Tests.swift
+++ b/Tests/SecureXPCTests/Client & Server/XPCRequestContext Tests.swift
@@ -22,7 +22,7 @@ class XPCRequestContextTest: XCTestCase {
         }
         server.start()
         
-        try await client.send(route: route)
+        try await client.send(toRoute: route)
     }
     
     func testGetEffectiveUserID_sync() throws {
@@ -39,7 +39,7 @@ class XPCRequestContextTest: XCTestCase {
         }
         server.start()
         
-        client.send(route: route, onCompletion: nil)
+        client.send(toRoute: route, onCompletion: nil)
         
         self.waitForExpectations(timeout: 1)
     }
@@ -54,7 +54,7 @@ class XPCRequestContextTest: XCTestCase {
         }
         server.start()
         
-        try await client.send(route: route)
+        try await client.send(toRoute: route)
     }
     
     func testGetEffectiveGroupID_sync() throws {
@@ -71,7 +71,7 @@ class XPCRequestContextTest: XCTestCase {
         }
         server.start()
         
-        client.send(route: route, onCompletion: nil)
+        client.send(toRoute: route, onCompletion: nil)
         
         self.waitForExpectations(timeout: 1)
     }
@@ -91,7 +91,7 @@ class XPCRequestContextTest: XCTestCase {
         }
         server.start()
         
-        try await client.send(route: route)
+        try await client.send(toRoute: route)
     }
     
     func testGetClientCode_sync() throws {
@@ -113,7 +113,7 @@ class XPCRequestContextTest: XCTestCase {
         }
         server.start()
         
-        client.send(route: route, onCompletion: nil)
+        client.send(toRoute: route, onCompletion: nil)
         
         self.waitForExpectations(timeout: 1)
     }


### PR DESCRIPTION
This is done to align with Swift's API Guidelines that state, "Prefer method and function names that make use sites form grammatical English phrases."

The `toRoute` parameter is always the first or second parameter, which makes it quite important. As the guidelines further state, "It is acceptable for fluency to degrade after the first argument or two when those arguments are not central to the call’s meaning."

There are no functional changes to this PR, just a naming change. Of course this is a breaking change.