### PR TITLE
Adds `requestID` to all requests and responses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 xcuserdata/
 DerivedData/
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.swiftpm/xcode/xcshareddata/xcschemes/SecureXPCTests.xcscheme

--- a/Sources/SecureXPC/XPC Coders/XPCDecoder/XPCDecoder.swift
+++ b/Sources/SecureXPC/XPC Coders/XPCDecoder/XPCDecoder.swift
@@ -44,7 +44,7 @@ enum XPCDecoder {
             // Ideally this would throw DecodingError.keyNotFound(...) but that requires providing a CodingKey
             // and there isn't one yet
             let context = DecodingError.Context(codingPath: [CodingKey](),
-                                                debugDescription: "Key not present: \(key)",
+                                                debugDescription: "Key not present: \(String(cString: key))",
                                                 underlyingError: nil)
             throw DecodingError.valueNotFound(type, context)
         }


### PR DESCRIPTION
All requests now have a unique identifier and all replies reference this identifier. This is currently useless as the XPC framework itself makes sure that replies are associated back with their requests.

The reason for adding a `requestID` is to enable server handlers to respond with multiple values per request. From the client perspective this will be exposed as an `AsyncSequence` (and some sort of backwards compatibility closure-based version as well). These responses will in fact be sends from the server to the client, containing the `requestID` which then allows for them to be properly associated.

While there will probably be a fair amount of complexity under-the-hood to enable these multi-response scenarios, I believe it should be quite simple from an API user perspective - far simpler than arbitrary sends from the server to the client - so I'm excited to add this.

Since this is a fully separable (although by itself useless) part, I thought it best for it to have its own PR first.