### PR TITLE
Renames `NonBlockingServer` to `XPCNonBlockingServer`

### DIFF
--- a/Sources/SecureXPC/Client/XPCClient.swift
+++ b/Sources/SecureXPC/Client/XPCClient.swift
@@ -186,7 +186,7 @@ public class XPCClient {
 
     /// Provides a client to communicate with the server corresponding to the provided endpoint.
     ///
-    /// A server's endpoint is accesible via ``NonBlockingServer/endpoint``. The endpoint can be sent across an XPC connection.
+    /// A server's endpoint is accesible via ``XPCNonBlockingServer/endpoint``. The endpoint can be sent across an XPC connection.
 	public static func forEndpoint(_ endpoint: XPCServerEndpoint) -> XPCClient {
         let connection = xpc_connection_create_from_endpoint(endpoint.endpoint)
 

--- a/Sources/SecureXPC/SecureXPC.docc/SecureXPC.md
+++ b/Sources/SecureXPC/SecureXPC.docc/SecureXPC.md
@@ -70,7 +70,7 @@ See ``XPCClient`` for more on how to retrieve a client and send requests.
 ### Client and Server
 - ``XPCClient``
 - ``XPCServer``
-- ``NonBlockingServer``
+- ``XPCNonBlockingServer``
 - ``XPCServerEndpoint``
 
 ### Routes

--- a/Sources/SecureXPC/Server/XPCAnonymousServer.swift
+++ b/Sources/SecureXPC/Server/XPCAnonymousServer.swift
@@ -51,7 +51,7 @@ internal class XPCAnonymousServer: XPCServer {
     }
 }
 
-extension XPCAnonymousServer: NonBlockingServer {
+extension XPCAnonymousServer: XPCNonBlockingServer {
     public func start() {
         self.listenerQueue.sync {
             self.started = true

--- a/Sources/SecureXPC/Server/XPCMachServer.swift
+++ b/Sources/SecureXPC/Server/XPCMachServer.swift
@@ -58,7 +58,7 @@ internal class XPCMachServer: XPCServer {
     }
 }
 
-extension XPCMachServer: NonBlockingServer {
+extension XPCMachServer: XPCNonBlockingServer {
     public func start() {
         self.listenerQueue.sync {
             self.started = true

--- a/Sources/SecureXPC/XPCServerEndpoint.swift
+++ b/Sources/SecureXPC/XPCServerEndpoint.swift
@@ -9,7 +9,7 @@ import Foundation
 
 /// An endpoint is used to create clients which can communicate with their associated server.
 ///
-/// Endpoints are retrieved from a server's ``NonBlockingServer/endpoint`` property. They can be used in the same process or sent across an existing XPC
+/// Endpoints are retrieved from a server's ``XPCNonBlockingServer/endpoint`` property. They can be used in the same process or sent across an existing XPC
 /// connection.
 ///
 /// > Warning: While ``XPCServerEndpoint`` conforms to `Codable` it can only be encoded and decoded by the `SecureXPC` framework.


### PR DESCRIPTION
No functional changes. Since this is extremely closely related to `XPCServer` I thought it'd make more sense for the naming to also start with `XPC`.