### PR TITLE
Various internal improvements to sequential response

### DIFF
--- a/Tests/SecureXPCTests/Client & Server/Sequential Result Tests.swift
+++ b/Tests/SecureXPCTests/Client & Server/Sequential Result Tests.swift
@@ -8,8 +8,7 @@
 import XCTest
 @testable import SecureXPC
 
-
-class SequentailResultTests: XCTestCase {
+class SequentialResultTests: XCTestCase {
     
     var client: XPCClient! = nil
     let server = XPCServer.makeAnonymous()

--- a/Tests/SecureXPCTests/SecureXPCTests.swift
+++ b/Tests/SecureXPCTests/SecureXPCTests.swift
@@ -1,6 +1,0 @@
-import XCTest
-@testable import SecureXPC
-
-final class SecureXPCTests: XCTestCase {
-	
-}


### PR DESCRIPTION
The main improvement is that sequential replies use an XPC reply to keep open a transaction which should prevent the server from being terminated.