### PR TITLE
Adds `XPCServer.forThisLoginItem()` for login items installed with `SMLoginItemSetEnabled`

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@ later allowing clients to make non-blocking asynchronous requests to servers. A 
 providing compatibility back to OS X 10.10.
 
 This framework is ideal for communicating with helper tools installed via 
-[`SMJobBless`](https://developer.apple.com/documentation/servicemanagement/1431078-smjobbless). It's built with
-security in mind, minimizing the opportunities for 
+[`SMJobBless`](https://developer.apple.com/documentation/servicemanagement/1431078-smjobbless) and login items installed
+via
+[`SMLoginItemSetEnabled`](https://developer.apple.com/documentation/servicemanagement/1501557-smloginitemsetenabled).
+It's built with security in mind, minimizing the opportunities for 
 [exploits](https://objectivebythesea.com/v3/talks/OBTS_v3_wReguła.pdf). Server-side security checks are performed
 against the actual calling process instead of relying on PIDs which are known to be
 [insecure](https://saelo.github.io/presentations/warcon18_dont_trust_the_pid.pdf).

--- a/Sources/SecureXPC/Request.swift
+++ b/Sources/SecureXPC/Request.swift
@@ -11,11 +11,11 @@ import Foundation
 ///
 /// A request always contains a route and optionally contains a payload.
 struct Request {
-    
     private enum RequestKeys {
         static let route: XPCDictionaryKey = const("__route")
         static let payload: XPCDictionaryKey = const("__payload")
         static let requestID: XPCDictionaryKey = const("__request_id")
+        static let clientBookmark: XPCDictionaryKey = const("__client_bookmark")
     }
     
     /// The route represented by this request.
@@ -28,6 +28,8 @@ struct Request {
     ///
     /// If  `containsPayload` is `true` then `decodePayload` can be called to decode it; otherwise calling this function will result an error being thrown.
     let dictionary: xpc_object_t
+    /// A bookmark of the client's bundle. This allows a sandboxed server to validate the server's identity.
+    let clientBookmark: Data
     
     /// Represents a request that's already been encoded into an XPC dictionary.
     ///
@@ -36,7 +38,16 @@ struct Request {
         self.dictionary = dictionary
         self.route = try XPCDecoder.decode(XPCRoute.self, from: dictionary, forKey: RequestKeys.route)
         self.requestID = try XPCDecoder.decode(UUID.self, from: dictionary, forKey: RequestKeys.requestID)
+        self.clientBookmark = try XPCDecoder.decode(Data.self, from: dictionary, forKey: RequestKeys.clientBookmark)
         self.containsPayload = try XPCDecoder.containsKey(RequestKeys.payload, inDictionary: self.dictionary)
+    }
+    
+    /// Decodes just the client bookmark for a request that's already been encoded into an XPC dictionary.
+    ///
+    /// This is expected to be used by the server when determining whether to accept a request. Because the request could be an attempted exploit, this function
+    /// exists to minimize the amount of decoding we're doing (in comparison to initializing a Request instance) to reduce the exploitable surface area.
+    static func decodeClientBookmark(dictionary: xpc_object_t) throws -> Data {
+        return try XPCDecoder.decode(Data.self, from: dictionary, forKey: RequestKeys.clientBookmark)
     }
     
     /// Represents a request without a payload which has yet to be encoded into an XPC dictionary.
@@ -46,10 +57,12 @@ struct Request {
         self.route = route
         self.requestID = UUID()
         self.containsPayload = false
+        self.clientBookmark = try Bundle.main.bundleURL.bookmarkData()
         
         self.dictionary = xpc_dictionary_create(nil, nil, 0)
         xpc_dictionary_set_value(self.dictionary, RequestKeys.route, try XPCEncoder.encode(route))
         xpc_dictionary_set_value(self.dictionary, RequestKeys.requestID, try XPCEncoder.encode(requestID))
+        xpc_dictionary_set_value(self.dictionary, RequestKeys.clientBookmark, try XPCEncoder.encode(clientBookmark))
     }
     
     /// Represents a request with a payload which has yet to be encoded into an XPC dictionary.
@@ -59,11 +72,13 @@ struct Request {
         self.route = route
         self.requestID = UUID()
         self.containsPayload = true
+        self.clientBookmark = try Bundle.main.bundleURL.bookmarkData()
         
         self.dictionary = xpc_dictionary_create(nil, nil, 0)
         xpc_dictionary_set_value(self.dictionary, RequestKeys.route, try XPCEncoder.encode(self.route))
         xpc_dictionary_set_value(self.dictionary, RequestKeys.requestID, try XPCEncoder.encode(requestID))
-        xpc_dictionary_set_value(dictionary, RequestKeys.payload, try XPCEncoder.encode(payload))
+        xpc_dictionary_set_value(self.dictionary, RequestKeys.payload, try XPCEncoder.encode(payload))
+        xpc_dictionary_set_value(self.dictionary, RequestKeys.clientBookmark, try XPCEncoder.encode(clientBookmark))
     }
     
     /// Decodes the payload as the provided type.

--- a/Sources/SecureXPC/SecureXPC.docc/SecureXPC.md
+++ b/Sources/SecureXPC/SecureXPC.docc/SecureXPC.md
@@ -8,7 +8,9 @@ compatability.
 SecureXPC provides an easy way to perform secure XPC communication with pure Swift. `Codable` conforming types are used
 to make requests and receive responses. This framework can be used to communicate with any type of XPC service or XPC
 Mach service. Customized support for communicating with helper tools installed via 
-[`SMJobBless`](https://developer.apple.com/documentation/servicemanagement/1431078-smjobbless) is also provided.
+[`SMJobBless`](https://developer.apple.com/documentation/servicemanagement/1431078-smjobbless) and login items installed
+via [`SMLoginItemSetEnabled`](https://developer.apple.com/documentation/servicemanagement/1501557-smloginitemsetenabled)
+are also provided.
 
 ## Usage
 The envisioned pattern when using this framework is to define routes in a shared file, retrieve a server in one program

--- a/Sources/SecureXPC/Server/MessageAcceptor.swift
+++ b/Sources/SecureXPC/Server/MessageAcceptor.swift
@@ -10,6 +10,16 @@ import Foundation
 internal protocol MessageAcceptor {
     /// Determines whether an incoming message should be accepted.
     func acceptMessage(connection: xpc_connection_t, message: xpc_object_t) -> Bool
+    
+    /// Whether the `acceptor` is equivalent to this one.
+    func isEqual(to acceptor: MessageAcceptor) -> Bool
+}
+
+extension MessageAcceptor {
+    // Default implementation is based purely on matching types
+    func isEqual(to acceptor: MessageAcceptor) -> Bool {
+        return type(of: acceptor) == Self.self
+    }
 }
 
 /// This should only be used by XPC services which are application-scoped, so it's safe to assume they're inheritently safe.
@@ -25,6 +35,10 @@ internal struct AlwaysAcceptingMessageAcceptor: MessageAcceptor {
 
 /// This is intended for use by `XPCAnonymousServer`.
 internal struct SameProcessMessageAcceptor: MessageAcceptor {
+    static let instance = SameProcessMessageAcceptor()
+    
+    private init() { }
+    
     /// Accepts a message only if it is coming from this process.
     func acceptMessage(connection: xpc_connection_t, message: xpc_object_t) -> Bool {
         // In the case of an XPCAnonymousServer, all of the connections must be created after the server itself was
@@ -39,9 +53,13 @@ internal struct SameProcessMessageAcceptor: MessageAcceptor {
 /// Accepts messages which meet the provided code signing requirements.
 ///
 /// Uses undocumented functionality prior to macOS 11.
-internal struct SecureMessageAcceptor: MessageAcceptor {
+internal struct SecRequirementsMessageAcceptor: MessageAcceptor {
     /// At least one of these code signing requirements must be met in order for the message to be accepted
-    internal let requirements: [SecRequirement]
+    private let requirements: [SecRequirement]
+    
+    internal init(_ requirements: [SecRequirement]) {
+        self.requirements = requirements
+    }
     
     /// Accepts a message if it meets at least on of the provided `requirements`.
     ///
@@ -52,5 +70,97 @@ internal struct SecureMessageAcceptor: MessageAcceptor {
         }
         
         return self.requirements.contains { SecCodeCheckValidity(code, SecCSFlags(), $0) == errSecSuccess }
+    }
+    
+    func isEqual(to acceptor: MessageAcceptor) -> Bool {
+        guard let acceptor = acceptor as? SecRequirementsMessageAcceptor else {
+            return false
+        }
+        
+        // Transform the requirements into Data form so that they can be compared
+        let requirementTransform = { (requirement: SecRequirement) -> Data? in
+            var data: CFData?
+            if SecRequirementCopyData(requirement, SecCSFlags(), &data) == errSecSuccess, let data = data as Data? {
+                return data
+            } else {
+                return nil
+            }
+        }
+        
+        // Turn into sets so they can be compared without taking into account the order of requirements
+        let requirementsData = Set<Data>(self.requirements.compactMap(requirementTransform))
+        let otherRequirementsData = Set<Data>(acceptor.requirements.compactMap(requirementTransform))
+        
+        return requirementsData == otherRequirementsData
+    }
+}
+
+/// Accepts messages that originates from a directory containing this server.
+internal struct ParentBundleMessageAcceptor: MessageAcceptor {
+    
+    static let instance = ParentBundleMessageAcceptor()
+    
+    private init() { }
+    
+    func acceptMessage(connection: xpc_connection_t, message: xpc_object_t) -> Bool {
+        guard let clientCode = SecCodeCreateWithXPCConnection(connection, andMessage: message),
+              let clientPath = SecCodeCopyPath(clientCode) else {
+            return false
+        }
+        
+        var serverCode: SecCode?
+        guard SecCodeCopySelf(SecCSFlags(), &serverCode) == errSecSuccess,
+              let serverCode = serverCode,
+              let serverPath = SecCodeCopyPath(serverCode) else {
+            return false
+        }
+        
+        // TODO: change this logic so any path within the parent bundle's directory is accepted
+        // this will allow for other services, such as a Finder Sync Extension, to also communicate with the login item
+        
+        // If this is true, then the client path can't possibly be a parent directory
+        if clientPath.pathComponents.count > serverPath.pathComponents.count {
+            return false
+        }
+        
+        // Validate the each component in the client path is present in the server in path in the same order
+        for i in 0..<clientPath.pathComponents.count {
+            if clientPath.pathComponents[i] != serverPath.pathComponents[i] {
+                return false
+            }
+        }
+        
+        return true
+    }
+    
+    /// This needs to be computed each time and not stored because it's entirely valid for a running app's bundle directory to be moved.
+    /*
+    private func parentBundleLocation() -> URL? {
+        var code: SecCode?
+        guard SecCodeCopySelf(SecCSFlags(), &code) == errSecSuccess,
+              let code = code,
+              let path = SecCodeCopyPath(code) else {
+            return nil
+        }
+        
+        
+        
+        return nil
+    }*/
+    
+    private func SecCodeCopyPath(_ code: SecCode) -> URL? {
+        var staticCode: SecStaticCode?
+        guard SecCodeCopyStaticCode(code, SecCSFlags(), &staticCode) == errSecSuccess,
+              let staticCode = staticCode else {
+            return nil
+        }
+        
+        var path: CFURL?
+        guard Security.SecCodeCopyPath(staticCode, SecCSFlags(), &path) == errSecSuccess,
+              let path = (path as URL?)?.standardized else {
+            return nil
+        }
+        
+        return path
     }
 }

--- a/Sources/SecureXPC/Server/XPCAnonymousServer.swift
+++ b/Sources/SecureXPC/Server/XPCAnonymousServer.swift
@@ -16,16 +16,10 @@ internal class XPCAnonymousServer: XPCServer {
     private var started = false
     /// Connections received while the server is not started
     private var pendingConnections = [xpc_connection_t]()
-    /// Determines if an incoming request will be accepted based on the provided client requirements
-    private let _messageAcceptor: MessageAcceptor
-    override internal var messageAcceptor: MessageAcceptor {
-        _messageAcceptor
-    }
     
-    internal init(messageAcceptor: MessageAcceptor) {
-        self._messageAcceptor = messageAcceptor
+    internal override init(messageAcceptor: MessageAcceptor) {
         self.anonymousListenerConnection = xpc_connection_create(nil, listenerQueue)
-        super.init()
+        super.init(messageAcceptor: messageAcceptor)
         
         // Configure listener for new anonymous connections, all received events are incoming client connections
         xpc_connection_set_event_handler(self.anonymousListenerConnection, { connection in
@@ -42,12 +36,6 @@ internal class XPCAnonymousServer: XPCServer {
     public override func startAndBlock() -> Never {
         self.start()
         dispatchMain()
-    }
-
-    internal func simulateDisconnectionForTesting() {
-        xpc_connection_cancel(self.anonymousListenerConnection)
-        // A new event handler must be set otherwise the existing one will still be used even after cancellation
-        xpc_connection_set_event_handler(self.anonymousListenerConnection, { _ in })
     }
 }
 

--- a/Sources/SecureXPC/Server/XPCMachServer.swift
+++ b/Sources/SecureXPC/Server/XPCMachServer.swift
@@ -21,23 +21,17 @@ internal class XPCMachServer: XPCServer {
     private var started = false
     /// Connections received while the server is not started
     private var pendingConnections = [xpc_connection_t]()
-    /// Determines if an incoming request will be accepted based on the provided client requirements
-    private let _messageAcceptor: SecureMessageAcceptor
-    override internal var messageAcceptor: MessageAcceptor {
-        _messageAcceptor
-    }
     
     /// This should only ever be called from `getXPCMachServer(...)` so that client requirement invariants are upheld.
-    private init(machServiceName: String, clientRequirements: [SecRequirement]) {
+    private init(machServiceName: String, messageAcceptor: MessageAcceptor) {
         self.machServiceName = machServiceName
-        self._messageAcceptor = SecureMessageAcceptor(requirements: clientRequirements)
         let listenerQueue = DispatchQueue(label: String(describing: XPCMachServer.self))
         // Attempts to bind to the Mach service. If this isn't actually a Mach service a EXC_BAD_INSTRUCTION will occur.
         self.listenerConnection = machServiceName.withCString { namePointer in
             xpc_connection_create_mach_service(namePointer, listenerQueue, UInt64(XPC_CONNECTION_MACH_SERVICE_LISTENER))
         }
         self.listenerQueue = listenerQueue
-        super.init()
+        super.init(messageAcceptor: messageAcceptor)
         
         // Configure listener for new connections, all received events are incoming client connections
         xpc_connection_set_event_handler(self.listenerConnection, { connection in
@@ -95,49 +89,79 @@ extension XPCMachServer {
     /// Prevents race conditions for creating and retrieving cached Mach servers
     private static let serialQueue = DispatchQueue(label: "XPCMachServer Retrieval Queue")
     
-    /// Returns a server with the provided name and requirements OR throws an error if that's not possible.
+    /// Returns a server with the provided name and an equivalent message acceptor OR throws an error if that's not possible.
     ///
     /// Decision tree:
     /// - If a server exists with that name:
-    ///   - If the client requirements match, return the server.
-    ///   - Else the client requirements do not match, throw an error.
+    ///   - If the message acceptors are equivalent, return the server.
+    ///   - Else, throw an error.
     /// - Else no server exists in the cache with the provided name, create one, store it in the cache, and return it.
     ///
     /// This behavior prevents ending up with two servers for the same named XPC Mach service.
     internal static func getXPCMachServer(named machServiceName: String,
-                                          clientRequirements: [SecRequirement]) throws -> XPCMachServer {
+                                          messageAcceptor: MessageAcceptor) throws -> XPCMachServer {
         // Force serial execution to prevent a race condition where multiple XPCMachServer instances for the same Mach
         // service name are created and returned
         try serialQueue.sync {
             let server: XPCMachServer
             if let cachedServer = machServerCache[machServiceName] {
-                // Transform the requirements into Data form so that they can be compared
-                let requirementTransform = { (requirement: SecRequirement) throws -> Data in
-                    var data: CFData?
-                    if SecRequirementCopyData(requirement, [], &data) == errSecSuccess,
-                       let data = data as Data? {
-                        return data
-                    } else {
-                        throw XPCError.unknown
-                    }
-                }
-                
-                // Turn into sets so they can be compared without taking into account the order of requirements
-                let requirementsData = Set<Data>(try clientRequirements.map(requirementTransform))
-                let cachedRequirementsData = Set<Data>(try cachedServer._messageAcceptor.requirements
-                                                                       .map(requirementTransform))
-                guard requirementsData == cachedRequirementsData else {
+                if !messageAcceptor.isEqual(to: cachedServer.messageAcceptor) {
                     throw XPCError.conflictingClientRequirements
                 }
-                
                 server = cachedServer
             } else {
-                server = XPCMachServer(machServiceName: machServiceName, clientRequirements: clientRequirements)
+                server = XPCMachServer(machServiceName: machServiceName, messageAcceptor: messageAcceptor)
                 machServerCache[machServiceName] = server
             }
             
             return server
         }
+    }
+    
+    internal static func _forThisLoginItem() throws -> XPCMachServer {
+        // There's no public way to definitively determine this code is actually running as part of a login item, but
+        // at a minimum it's possible to determine if we're *not* one based on the required directory structure.
+        //
+        // From SMLoginItemSetEnabled:
+        // https://developer.apple.com/documentation/servicemanagement/1501557-smloginitemsetenabled
+        //     Enables a helper tool in the main app bundle’s Contents/Library/LoginItems directory.
+        func validatePathComponent(_ path: URL, expectedLastComponent: String) throws -> URL {
+            if path.lastPathComponent != expectedLastComponent {
+                let message = "A login item helper tool must be located within the main app bundle's " +
+                              "Contents/Library/LoginItems directory.\n" +
+                              "Expected path component: \(expectedLastComponent)\n" +
+                              "Actual path component: \(path.lastPathComponent)"
+                throw XPCError.misconfiguredLoginItem(message)
+            }
+            
+            return path.deletingLastPathComponent()
+        }
+        
+        let loginItemsDir = Bundle.main.bundleURL.deletingLastPathComponent() // removes the login item's app bundle
+        let libraryDir = try validatePathComponent(loginItemsDir, expectedLastComponent: "LoginItems")
+        let contentsDir = try validatePathComponent(libraryDir, expectedLastComponent: "Library")
+        let parentAppBundle = try validatePathComponent(contentsDir, expectedLastComponent: "Contents")
+        
+        if parentAppBundle.pathExtension != "app" {
+            let message = "A login item helper tool must be located within a main app bundle, but the containing " +
+                          "directory is not an app bundle.\n" +
+                          "Expected path extension: app\n" +
+                          "Actual path extension: \(parentAppBundle.pathExtension)"
+            throw XPCError.misconfiguredLoginItem(message)
+        }
+        
+        // Note: due to sandboxing, there's a good chance we can't actually access the parent app bundle to do any sort
+        // of validation (like checking it's actually a bundle) or reading its Info.plist
+        
+        // From Apple's AppSandboxLoginItemXPCDemo:
+        // https://developer.apple.com/library/archive/samplecode/AppSandboxLoginItemXPCDemo/
+        //     LaunchServices implicitly registers a mach service for the login item whose name is the same as the
+        //     login item's bundle identifier.
+        guard let bundleID = Bundle.main.bundleIdentifier else {
+            throw XPCError.misconfiguredLoginItem("The bundle identifier is missing; login items must have one")
+        }
+        
+        return try getXPCMachServer(named: bundleID, messageAcceptor: ParentBundleMessageAcceptor.instance)
     }
 
     internal static func _forThisBlessedHelperTool() throws -> XPCMachServer {
@@ -181,8 +205,9 @@ extension XPCMachServer {
         if clientRequirements.isEmpty {
             throw XPCError.misconfiguredBlessedHelperTool("No requirements were generated from SMAuthorizedClients")
         }
+        let messageAcceptor = SecRequirementsMessageAcceptor(clientRequirements)
 
-        return try getXPCMachServer(named: machServiceName, clientRequirements: clientRequirements)
+        return try getXPCMachServer(named: machServiceName, messageAcceptor: messageAcceptor)
     }
 
     /// Read the property list embedded within this helper tool.

--- a/Sources/SecureXPC/Server/XPCServer.swift
+++ b/Sources/SecureXPC/Server/XPCServer.swift
@@ -24,19 +24,21 @@ import Foundation
 /// ```
 ///
 /// #### XPC Mach services
-/// Launch Agents, Launch Daemons, and helper tools installed with
-/// [`SMJobBless`](https://developer.apple.com/documentation/servicemanagement/1431078-smjobbless) can optionally communicate
-/// over XPC by using Mach services.
+/// Launch Agents, Launch Daemons, helper tools installed with
+/// [`SMJobBless`](https://developer.apple.com/documentation/servicemanagement/1431078-smjobbless), and login items installed with
+/// [`SMLoginItemSetEnabled`](https://developer.apple.com/documentation/servicemanagement/1501557-smloginitemsetenabled) can
+/// optionally communicate over XPC by using Mach services.
 ///
-/// In most cases, a server can be auto-configured for a helper tool installed with `SMJobBless`:
+/// In most cases, a server can be auto-configured using ``XPCServer/forThisBlessedHelperTool()`` for a helper tool installed with `SMJobBless`:
 /// ```swift
 /// let server = try XPCServer.forThisBlessedHelperTool()
 /// ```
-/// See ``XPCServer/forThisBlessedHelperTool()`` for the exact requirements which need to be met.
 ///
-/// For Launch Agents, Launch Daemons, more advanced `SMJobBless` helper tool configurations, as well as other cases it is necessary both to the specify the
-/// name of the service as well its security requirements. See ``XPCServer/forThisMachService(named:clientRequirements:)`` for an example and
-/// details.
+/// Similarly, a server can be auto-configured using ``XPCServer/forThisLoginItem()`` for a login item installed with `SMLoginItemSetEnabled`.
+///
+/// For Launch Agents, Launch Daemons, more advanced `SMJobBless` and `SMLoginItemSetEnabled` configurations, as well as other cases it is
+/// necessary both to the specify the name of the service as well its security requirements. See
+/// ``XPCServer/forThisMachService(named:clientRequirements:)`` for an example and details.
 ///
 /// #### Anonymous servers
 /// An anonymous server can be created by any macOS program. Use cases for making one include:
@@ -556,7 +558,7 @@ extension XPCServer {
     /// > Note: If you need this server to be communicated with by clients running in a different process, use ``makeAnonymous(clientRequirements:)``
     /// instead.
     public static func makeAnonymous() -> XPCServer & XPCNonBlockingServer {
-        XPCAnonymousServer(messageAcceptor: SameProcessMessageAcceptor.instance)
+        XPCAnonymousServer(messageAcceptor: SameProcessMessageAcceptor())
     }
 
     /// Creates a new anonymous server that accepts requests from clients which meet the security requirements.
@@ -619,7 +621,13 @@ extension XPCServer {
     /// Provides a server for this login item installed with
     /// [`SMLoginItemSetEnabled`](https://developer.apple.com/documentation/servicemanagement/1501557-smloginitemsetenabled).
     ///
-    /// Incoming requests will only be accepted from the main app containing this login item.
+    /// This function may successfully be called by both sandboxed and non-sandboxed login items. If this is a sandboxed login item, the
+    /// [`com.apple.security.application-groups`](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_security_application-groups)
+    /// entitlement must be present and one of the application groups must have a team identifier matching this login item's helper tool. Both sandboxed and
+    /// non-sandboxed apps must have a team identifier.
+    ///
+    /// Incoming requests will only be accepted from the main app or helper tools contained within the main app bundle. Additionally they must have the same team
+    /// identifier as this login item.
     ///
     /// > Important: No requests will be processed until ``startAndBlock()`` or ``XPCNonBlockingServer/start()`` is called.
     ///
@@ -659,7 +667,8 @@ extension XPCServer {
     /// error handler has been set then it is called with ``XPCError/insecure``.
     ///
     /// - Parameters:
-    ///   - named: The name of the Mach service this server should bind to. This name must be present in the launchd property list's `MachServices` entry.
+    ///   - named: The name of the Mach service this server should bind to. This name must be present in the launchd property list's `MachServices` entry
+    ///   or be implicitly registered by LaunchServices.
     ///   - clientRequirements: If a request is received from a client, it will only be processed if it meets one (or more) of these requirements.
     /// - Throws: ``XPCError/conflictingClientRequirements`` if a server for this named service has previously been retrieved with different client
     ///           requirements.

--- a/Sources/SecureXPC/Server/XPCServiceServer.swift
+++ b/Sources/SecureXPC/Server/XPCServiceServer.swift
@@ -11,7 +11,7 @@ import Foundation
 ///
 /// In the case of this framework, the XPC service is expected to be communicated with by an `XPCServiceClient`.
 internal class XPCServiceServer: XPCServer {
-	private static let service = XPCServiceServer(messageAcceptor: AlwaysAcceptingMessageAcceptor.instance)
+	private static let service = XPCServiceServer(messageAcceptor: AlwaysAcceptingMessageAcceptor())
     
     internal static func _forThisXPCService() throws -> XPCServiceServer {
         // An XPC service's package type must be equal to "XPC!", see Apple's documentation for details

--- a/Sources/SecureXPC/Server/XPCServiceServer.swift
+++ b/Sources/SecureXPC/Server/XPCServiceServer.swift
@@ -11,7 +11,7 @@ import Foundation
 ///
 /// In the case of this framework, the XPC service is expected to be communicated with by an `XPCServiceClient`.
 internal class XPCServiceServer: XPCServer {
-	private static let service = XPCServiceServer()
+	private static let service = XPCServiceServer(messageAcceptor: AlwaysAcceptingMessageAcceptor.instance)
     
     internal static func _forThisXPCService() throws -> XPCServiceServer {
         // An XPC service's package type must be equal to "XPC!", see Apple's documentation for details
@@ -55,9 +55,5 @@ internal class XPCServiceServer: XPCServer {
     public override var serviceName: String? {
         // This is safe to unwrap because it was already checked in `_forThisXPCService()`.
         Bundle.main.bundleIdentifier!
-    }
-    
-    override internal var messageAcceptor: MessageAcceptor {
-        AlwaysAcceptingMessageAcceptor.instance
     }
 }

--- a/Sources/SecureXPC/XPCError.swift
+++ b/Sources/SecureXPC/XPCError.swift
@@ -60,12 +60,14 @@ public enum XPCError: Error, Codable {
     case misconfiguredXPCService(String)
     /// The caller is not a login item installed with
     /// [`SMLoginItemSetEnabled`](https://developer.apple.com/documentation/servicemanagement/1501557-smloginitemsetenabled)
-    /// or it is misconfigured.
+    /// or its configuration is not compatible with ``XPCServer/forThisLoginItem()``.
     case misconfiguredLoginItem(String)
     /// An error thrown by a handler registered with a ``XPCServer`` route when processing a client's request.
     ///
     /// The associated value represents, and possibly contains, the error.
     case handlerError(HandlerError)
+    /// An error internal to the SecureXPC framework.
+    case internalFailure(String)
     /// Unknown error occurred.
     case unknown
     

--- a/Sources/SecureXPC/XPCError.swift
+++ b/Sources/SecureXPC/XPCError.swift
@@ -58,6 +58,10 @@ public enum XPCError: Error, Codable {
     ///
     /// The associated string is a descriptive error message.
     case misconfiguredXPCService(String)
+    /// The caller is not a login item installed with
+    /// [`SMLoginItemSetEnabled`](https://developer.apple.com/documentation/servicemanagement/1501557-smloginitemsetenabled)
+    /// or it is misconfigured.
+    case misconfiguredLoginItem(String)
     /// An error thrown by a handler registered with a ``XPCServer`` route when processing a client's request.
     ///
     /// The associated value represents, and possibly contains, the error.


### PR DESCRIPTION
From a API user perspective this is basically the equivalent of `forThisBlessedHelperTool()` for `SMJobBless`. Under the hood, the implementation is considerably different. I've tested this manually, but don't have any great ideas on how to go about doing this in automated fashion (without adopting/implementing an entire integration testing setup).