### PR TITLE
Adds missing `serviceName` implementations

### DIFF
--- a/Sources/SecureXPC/Server/XPCAnonymousServer.swift
+++ b/Sources/SecureXPC/Server/XPCAnonymousServer.swift
@@ -37,6 +37,10 @@ internal class XPCAnonymousServer: XPCServer {
         self.start()
         dispatchMain()
     }
+    
+    public override var serviceName: String? {
+        nil
+    }
 }
 
 extension XPCAnonymousServer: XPCNonBlockingServer {

--- a/Sources/SecureXPC/Server/XPCMachServer.swift
+++ b/Sources/SecureXPC/Server/XPCMachServer.swift
@@ -50,6 +50,10 @@ internal class XPCMachServer: XPCServer {
         // Park the main thread, allowing for incoming connections and requests to be processed
         dispatchMain()
     }
+    
+    public override var serviceName: String? {
+        machServiceName
+    }
 }
 
 extension XPCMachServer: XPCNonBlockingServer {


### PR DESCRIPTION
Was missing for `XPCAnonymousServer` and `XPCMachServer`