### PR TITLE
Partial support for macOS 13's new `SMAppService`

### DIFF
--- a/Sources/SecureXPC/XPCError.swift
+++ b/Sources/SecureXPC/XPCError.swift
@@ -66,6 +66,12 @@ public enum XPCError: Error, Codable {
     ///
     /// The associated string is a descriptive error message.
     case misconfiguredLoginItem(description: String)
+    /// The caller is not a daemon enabled via
+    /// [`SMAppService.daemon(...)`](https://developer.apple.com/documentation/servicemanagement/smappservice/3945410-daemon?changes=la_2)
+    /// and subsequently registered.
+    /// 
+    /// The associated string is a descriptive error message.
+    case misconfiguredDaemon(description: String)
     /// An error thrown by a handler registered with a ``XPCServer`` route when processing a client's request.
     ///
     /// The associated value represents, and possibly contains, the error.


### PR DESCRIPTION
 - Adds support for daemons and this has been tested
 - Updates documentation for login items, which _may_ just work, but it's actually unclear because Apple's documentation right now is obviously incorrect. See https://developer.apple.com/forums/thread/709171#709171021
 - No support yet for launch agents

However, this is making the API surface increasing unwieldy so I have thoughts on how to refactor this to in most cases auto-detect which type of server  (and for that matter client as well) and let users explicitly specify a "type" if so desired. But first, wanted to land this change in the current style (although likely not make a release containing it).