### PR TITLE
Auto-detection of server and client types for most common cases

### DIFF
--- a/Sources/SecureXPC/Client/XPCAnonymousClient.swift
+++ b/Sources/SecureXPC/Client/XPCAnonymousClient.swift
@@ -9,14 +9,20 @@ import Foundation
 
 /// A concrete implementation of ``XPCClient`` which can communicate with an anonymous XPC listener connection.
 ///
-/// In the case of this framework, the anonymous listener connection is expected to be represented by an `XPCAnonymousServer`.
+/// In the case of this framework, the anonymous listener connection is expected to be represented by an `XPCAnonymousServer` or an `XPCServiceServer`
+/// in the case where its `endpoint` is used.
 internal class XPCAnonymousClient: XPCClient {
+    // The connection descriptor is passed in as opposed to be always being `anonymous` because an anonymous client can
+    // also be created to communicate with an endpoint returned by an XPCServiceServer and we want to preserve that
+    // information so it's accessible to the end user.
+    private let _connectionDescriptor: XPCConnectionDescriptor
     public override var connectionDescriptor: XPCConnectionDescriptor {
-        .anonymous
+        _connectionDescriptor
     }
 
     // Anonymous clients *must* be created from an existing connection.
-    init(connection: xpc_connection_t) {
+    internal init(connection: xpc_connection_t, connectionDescriptor: XPCConnectionDescriptor) {
+        self._connectionDescriptor = connectionDescriptor
         super.init(connection: connection)
     }
     

--- a/Sources/SecureXPC/Client/XPCClient.swift
+++ b/Sources/SecureXPC/Client/XPCClient.swift
@@ -9,49 +9,21 @@ import Foundation
 
 /// An XPC client to make requests and receive responses from an ``XPCServer``.
 ///
-/// ### Retrieving a Client
-/// There are two different types of services you can communicate with using this client: XPC services and XPC Mach services. If you are uncertain which
-/// type of service you're using, it's likely an XPC service.
-///
-/// Clients can also be created from an ``XPCServerEndpoint`` which is the only way to create a client for an anonymous server.
-///
-/// #### XPC services
-/// These are helper tools which ship as part of your app and only your app can communicate with.
-///
-/// The name of the service must be specified when retrieving a client to talk to your XPC service; this is always the bundle identifier for the service:
+/// ### Retrieving a Client For a Service
+/// There are two different types of services you can communicate with using this client: XPC services and XPC Mach services. In most cases you do not need to
+/// know which type you'll be communicating with as this will be auto-detected, so creating a client only requires providing its name:
 /// ```swift
-/// let client = XPCClient.forXPCService(named: "com.example.myapp.service")
+/// let client = XPCClient.forService(named: "com.example.myapp.service")
 /// ```
 ///
-/// The service itself must create and configure an ``XPCServer`` by calling ``XPCServer/forThisXPCService()`` in order for this client to be able to
-/// communicate with it.
+/// It is possible to explicitly specify the type of client which will be returned and in some uncommon cases this will is required. See ``ServiceType`` for details.
 ///
-/// #### XPC Mach services
-/// Launch Agents, Launch Daemons, helper tools installed with
-/// [  `SMJobBless`](https://developer.apple.com/documentation/servicemanagement/1431078-smjobbless),  and login items installed with
-/// [`SMLoginItemSetEnabled`](https://developer.apple.com/documentation/servicemanagement/1501557-smloginitemsetenabled)
-/// can optionally communicate over XPC by using Mach services.
-///
-/// The name of the service must be specified when retrieving a client:
-/// ```swift
-/// let client = XPCClient.forMachService(named: "com.example.service")
-/// ```
-///
-/// The service's name is defined differently depending on its type:
-/// - For an `SMJobBless` helper tool this must be a key in the `MachServices` entry of the tool's launchd property list
-/// - For an `SMLoginItemSetEnabled` login item it is the bundle's identifier
-/// - For a Launch Agent or Launch Daemon it's defined in the property list used when registering with launchd
-///
-/// The service itself must retrieve and configure an ``XPCServer`` by calling ``XPCServer/forThisMachService(named:clientRequirements:)``,
-/// ``XPCServer/forThisBlessedHelperTool()``, or ``XPCServer/forThisLoginItem()`` in order for this client to be able to communicate with it.
-///
-/// #### Endpoints
-/// Clients can be created from server endpoints:
+/// ## Retrieving a Client For an Anonymous Server
+/// Clients can also be created from an ``XPCServerEndpoint`` which is the only way to create a client for an anonymous server:
 /// ```swift
 /// let server = XPCServer.makeAnonymous()
 /// let client = XPCClient.forEndpoint(server.endpoint)
 /// ```
-/// Server endpoints can also be sent across XPC connections.
 ///
 /// ### Sending Requests with Async
 /// Once a client has been retrieved, sending a request is as simple as invoking `send` with a route:
@@ -132,8 +104,8 @@ import Foundation
 ///
 /// ## Topics
 /// ### Retrieving a Client
-/// - ``forXPCService(named:)``
-/// - ``forMachService(named:)``
+/// - ``forService(named:ofType:)``
+/// - ``ServiceType``
 /// - ``forEndpoint(_:)``
 /// ### Sending Requests with Async
 /// - ``send(to:)-5b1ar``
@@ -158,38 +130,89 @@ public class XPCClient {
     
     // MARK: Public factories
     
-    /// Provides a client to communicate with an XPC service.
-    ///
-    /// An XPC service is a helper tool which ships as part of your app and only your app can communicate with.
-    ///
-    /// In order for this client to be able to communicate with the XPC service, the service itself must retrieve and configure an ``XPCServer`` by calling
-    /// ``XPCServer/forThisXPCService()``.
-    ///
-    /// > Note: Client creation always succeeds regardless of whether the XPC service actually exists.
-    ///
-    /// - Parameters:
-    ///   - named: The bundle identifier of the XPC Service.
-    /// - Returns: A client configured to communicate with the named service.
-    public static func forXPCService(named xpcServiceName: String) -> XPCClient {
-        XPCServiceClient(xpcServiceName: xpcServiceName)
+    /// The type of service an ``XPCClient`` should be retrieved for.
+    public enum ServiceType {
+        /// Auto-detects what type of client to retrieve for the name provided to ``XPCClient/forService(named:ofType:)``.
+        ///
+        /// This is accomplished by finding the names (`CFBundleIdentifier`s) for each of the XPC services bundled with this app. If the name provided
+        /// to `forService(named:ofType:)` belongs to one of the XPC services then a client will be created to communicate with it. Otherwise, a client
+        /// will be created to communicate with an XPC Mach service.
+        ///
+        /// If there is a Mach service you need to communicate with that has the same name as a bundled XPC service, explicitly retrieve the client as such
+        /// by passing in ``machService`` as the type.
+        case autoDetect
+        /// Ensures the client returned by ``XPCClient/forService(named:ofType:)`` communicates with an XPC Mach service with the provided
+        /// name.
+        ///
+        /// Launch Agents, Launch Daemons, helper tools installed with
+        /// [  `SMJobBless`](https://developer.apple.com/documentation/servicemanagement/1431078-smjobbless),
+        /// and login items installed with
+        /// [`SMLoginItemSetEnabled`](https://developer.apple.com/documentation/servicemanagement/1501557-smloginitemsetenabled)
+        /// can all optionally communicate over XPC by using Mach services.
+        case machService
+        /// Ensures the client returned by ``XPCClient/forService(named:ofType:)`` communicates with an XPC service with the provided name.
+        ///
+        /// XPC services are helper tools which ship as part of your app and only your app can communicate with.
+        ///
+        /// It is a programming error to specify this type and provide `forService(named:ofType:)` a name which does not correspond to an XPC service
+        /// bundled with the calling app. You may find this behavior helpful for debugging purposes.
+        case xpcService
     }
     
-    /// Provides a client to communicate with an XPC Mach service.
+    /// Provides a client to communicate with a service.
     ///
-    /// XPC Mach services are often used by tools such as Launch Agents, Launch Daemons, and helper tools installed with
-    /// [  `SMJobBless`](https://developer.apple.com/documentation/servicemanagement/1431078-smjobbless).
+    /// In order for this client to be able to communicate with the service, the service itself must retrieve and configure an ``XPCServer`` by calling
+    /// ``XPCServer/forThisProcess(ofType:)``.
     ///
-    /// In order for this client to be able to communicate with the tool, the tool itself must retrieve and configure an ``XPCServer`` by calling
-    /// ``XPCServer/forThisMachService(named:clientRequirements:)`` or ``XPCServer/forThisBlessedHelperTool()``.
-    ///
-    /// > Note: Client creation always succeeds regardless of whether the XPC Mach service actually exists.
+    /// > Note: Client creation can succeed regardless of whether the service actually exists.
     ///
     /// - Parameters:
-    ///    - named: A key in the `MachServices` entry of the tool's launchd property list.
+    ///   - named: The `CFBundleIdentifier` of the XPC service or the name of the XPC Mach service. For most Mach services the name is specified
+    ///            with the `MachServices` launchd property list entry; however, for login items the name is its`CFBundleIdentifier`.
+    ///   - ofType: There are multiple different types of XPC clients and normally you do not need to concern yourself with this. However, if you are trying to
+    ///             create a client for an XPC Mach service *and* you have an XPC service with a CFBundleIdentifier value that's the same as the name of
+    ///             that Mach service, then you must call this function and explicitly set the type to ``ServiceType/machService``. This is because auto
+    ///             detection will always choose the XPC service if one exists with the provided name.
     /// - Returns: A client configured to communicate with the named service.
-    public static func forMachService(named machServiceName: String) -> XPCClient {
-        XPCMachClient(machServiceName: machServiceName)
+    public static func forService(named serviceName: String, ofType type: ServiceType = .autoDetect) -> XPCClient {
+        switch type {
+            case .autoDetect:
+                if bundledXPCServiceIdentifiers.contains(serviceName) {
+                    return XPCServiceClient(xpcServiceName: serviceName)
+                } else {
+                    return XPCMachClient(machServiceName: serviceName)
+                }
+            case .xpcService:
+                guard bundledXPCServiceIdentifiers.contains(serviceName) else {
+                    let message = "There is no bundled XPC service with name \(serviceName)\n" +
+                                  "Available XPC service names are:\n" +
+                                  bundledXPCServiceIdentifiers.joined(separator: "\n")
+                    fatalError(message)
+                }
+                
+                return XPCServiceClient(xpcServiceName: serviceName)
+            case .machService:
+                return XPCMachClient(machServiceName: serviceName)
+        }
     }
+    
+    /// The `CFBundleIdentifier` values for every `.xpc` file in the `Contents/XPCServices` of this app (if it exists).
+    private static let bundledXPCServiceIdentifiers: Set<String> = {
+        var xpcServiceBundleIdentifiers = Set<String>()
+        let servicesDir = Bundle.main.bundleURL.appendingPathComponent("Contents")
+                                               .appendingPathComponent("XPCServices")
+        if let bundleNames = try? FileManager.default.contentsOfDirectory(atPath: servicesDir.path) {
+            for bundleName in bundleNames {
+                if bundleName.hasSuffix(".xpc"),
+                   let bundle = Bundle(url: servicesDir.appendingPathComponent(bundleName)),
+                   let bundleIdentifier = bundle.infoDictionary?[kCFBundleIdentifierKey as String] as? String {
+                    xpcServiceBundleIdentifiers.insert(bundleIdentifier)
+                }
+            }
+        }
+        
+        return xpcServiceBundleIdentifiers
+    }()
 
     /// Provides a client to communicate with the server corresponding to the provided endpoint.
     ///

--- a/Sources/SecureXPC/Client/XPCClient.swift
+++ b/Sources/SecureXPC/Client/XPCClient.swift
@@ -227,9 +227,11 @@ public class XPCClient {
 
         switch endpoint.connectionDescriptor {
             case .anonymous:
-                return XPCAnonymousClient(connection: connection)
-            case .xpcService(name: let name):
-                return XPCServiceClient(xpcServiceName: name, connection: connection)
+                return XPCAnonymousClient(connection: connection, connectionDescriptor: .anonymous)
+            // XPCServiceServer creates an anonymous listener connection in order to provide an endpoint, so an
+            // anonymous client needs to be created to connect to it, but we want to preserve the connection descriptor
+            case .xpcService(_):
+                return XPCAnonymousClient(connection: connection, connectionDescriptor: endpoint.connectionDescriptor)
             case .machService(name: let name):
                 return XPCMachClient(machServiceName: name, connection: connection)
         }

--- a/Sources/SecureXPC/Client/XPCClient.swift
+++ b/Sources/SecureXPC/Client/XPCClient.swift
@@ -198,20 +198,17 @@ public class XPCClient {
     
     /// The `CFBundleIdentifier` values for every `.xpc` file in the `Contents/XPCServices` of this app (if it exists).
     private static let bundledXPCServiceIdentifiers: Set<String> = {
-        var xpcServiceBundleIdentifiers = Set<String>()
         let servicesDir = Bundle.main.bundleURL.appendingPathComponent("Contents")
                                                .appendingPathComponent("XPCServices")
-        if let bundleNames = try? FileManager.default.contentsOfDirectory(atPath: servicesDir.path) {
-            for bundleName in bundleNames {
-                if bundleName.hasSuffix(".xpc"),
-                   let bundle = Bundle(url: servicesDir.appendingPathComponent(bundleName)),
-                   let bundleIdentifier = bundle.infoDictionary?[kCFBundleIdentifierKey as String] as? String {
-                    xpcServiceBundleIdentifiers.insert(bundleIdentifier)
-                }
-            }
+        guard let servicesContents = try? FileManager.default.contentsOfDirectory(atPath: servicesDir.path) else {
+            return []
         }
         
-        return xpcServiceBundleIdentifiers
+        let xpcBundleNames = servicesContents.filter { $0.hasSuffix(".xpc") }
+        let xpcBundles = xpcBundleNames.compactMap { Bundle(url: servicesDir.appendingPathComponent($0)) }
+        let xpcBundleIDs = xpcBundles.compactMap { $0.infoDictionary?[kCFBundleIdentifierKey as String] as? String }
+        
+        return Set<String>(xpcBundleIDs)
     }()
 
     /// Provides a client to communicate with the server corresponding to the provided endpoint.

--- a/Sources/SecureXPC/Client/XPCClient.swift
+++ b/Sources/SecureXPC/Client/XPCClient.swift
@@ -37,7 +37,7 @@ import Foundation
 /// let client = XPCClient.forMachService(named: "com.example.service")
 /// ```
 ///
-/// The sservice's name is defined differently depending on its type:
+/// The service's name is defined differently depending on its type:
 /// - For an `SMJobBless` helper tool this must be a key in the `MachServices` entry of the tool's launchd property list
 /// - For an `SMLoginItemSetEnabled` login item it is the bundle's identifier
 /// - For a Launch Agent or Launch Daemon it's defined in the property list used when registering with launchd
@@ -193,7 +193,7 @@ public class XPCClient {
 
     /// Provides a client to communicate with the server corresponding to the provided endpoint.
     ///
-    /// A server's endpoint is accesible via ``XPCNonBlockingServer/endpoint``. The endpoint can be sent across an XPC connection.
+    /// A server's endpoint is accesible via ``XPCServer/endpoint``. The endpoint can be sent across an XPC connection.
 	public static func forEndpoint(_ endpoint: XPCServerEndpoint) -> XPCClient {
         let connection = xpc_connection_create_from_endpoint(endpoint.endpoint)
 

--- a/Sources/SecureXPC/SecureXPC.docc/SecureXPC.md
+++ b/Sources/SecureXPC/SecureXPC.docc/SecureXPC.md
@@ -6,11 +6,13 @@ compatability.
 ## Overview
 
 SecureXPC provides an easy way to perform secure XPC communication with pure Swift. `Codable` conforming types are used
-to make requests and receive responses. This framework can be used to communicate with any type of XPC service or XPC
-Mach service. Customized support for communicating with helper tools installed via 
+to make requests and receive responses.
+
+This framework can be used to communicate with any type of XPC service or XPC Mach service. Built-in support for
+communicating with helper tools installed via 
 [`SMJobBless`](https://developer.apple.com/documentation/servicemanagement/1431078-smjobbless) and login items installed
 via [`SMLoginItemSetEnabled`](https://developer.apple.com/documentation/servicemanagement/1501557-smloginitemsetenabled)
-are also provided.
+is also provided.
 
 ## Usage
 The envisioned pattern when using this framework is to define routes in a shared file, retrieve a server in one program
@@ -34,7 +36,7 @@ In one program retrieve a server, register those routes, and then start the serv
     ...
     let server = XPCServer.forThisProcess()
     server.registerRoute(route, handler: bedazzle)
-    server.start()
+    server.startAndBlock()
 }
 
 private func bedazzle(message: String) throws -> Bool {
@@ -50,13 +52,13 @@ See ``XPCServer`` for details on how to retrieve, configure, and start a server.
 
 In another program retrieve a client, then send a request to one of these routes:
 ```swift
-let client = <# client retrieval here #>
+let client = XPCClient.forService(named: "com.example.service")
 let reply = try await client.sendMessage("Get Schwifty", to: route)
 ```
 
 Closure-based variants are available for macOS 10.14 and earlier:
 ```swift
-let client = <# client retrieval here #>
+let client = XPCClient.forService(named: "com.example.service")
 try client.sendMessage("Get Schwifty", to: route, withResponse: { response in
     switch response {
         case .success(let reply):

--- a/Sources/SecureXPC/SecureXPC.docc/SecureXPC.md
+++ b/Sources/SecureXPC/SecureXPC.docc/SecureXPC.md
@@ -32,7 +32,7 @@ See ``XPCRoute`` to learn more about how to create routes.
 In one program retrieve a server, register those routes, and then start the server:
 ```swift
     ...
-    let server = <# server retrieval here #>
+    let server = XPCServer.forThisProcess()
     server.registerRoute(route, handler: bedazzle)
     server.start()
 }

--- a/Sources/SecureXPC/Server/XPCAnonymousServer.swift
+++ b/Sources/SecureXPC/Server/XPCAnonymousServer.swift
@@ -41,6 +41,13 @@ internal class XPCAnonymousServer: XPCServer {
     public override var connectionDescriptor: XPCConnectionDescriptor {
         .anonymous
     }
+    
+    public override var endpoint: XPCServerEndpoint? {
+        XPCServerEndpoint(
+            connectionDescriptor: .anonymous,
+            endpoint: xpc_endpoint_create(self.anonymousListenerConnection)
+        )
+    }
 }
 
 extension XPCAnonymousServer: XPCNonBlockingServer {
@@ -52,12 +59,5 @@ extension XPCAnonymousServer: XPCNonBlockingServer {
             }
             self.pendingConnections.removeAll()
         }
-    }
-    
-    public var endpoint: XPCServerEndpoint {
-        XPCServerEndpoint(
-            connectionDescriptor: .anonymous,
-            endpoint: xpc_endpoint_create(self.anonymousListenerConnection)
-        )
     }
 }

--- a/Sources/SecureXPC/Server/XPCAnonymousServer.swift
+++ b/Sources/SecureXPC/Server/XPCAnonymousServer.swift
@@ -42,11 +42,9 @@ internal class XPCAnonymousServer: XPCServer {
         .anonymous
     }
     
-    public override var endpoint: XPCServerEndpoint? {
-        XPCServerEndpoint(
-            connectionDescriptor: .anonymous,
-            endpoint: xpc_endpoint_create(self.anonymousListenerConnection)
-        )
+    public override var endpoint: XPCServerEndpoint {
+        XPCServerEndpoint(connectionDescriptor: .anonymous,
+                        endpoint: xpc_endpoint_create(self.anonymousListenerConnection))
     }
 }
 

--- a/Sources/SecureXPC/Server/XPCMachServer.swift
+++ b/Sources/SecureXPC/Server/XPCMachServer.swift
@@ -55,11 +55,9 @@ internal class XPCMachServer: XPCServer {
         .machService(name: machServiceName)
     }
     
-    public override var endpoint: XPCServerEndpoint? {
-        XPCServerEndpoint(
-            connectionDescriptor: .machService(name: self.machServiceName),
-            endpoint: xpc_endpoint_create(self.listenerConnection)
-        )
+    public override var endpoint: XPCServerEndpoint {
+        XPCServerEndpoint(connectionDescriptor: .machService(name: self.machServiceName),
+                          endpoint: xpc_endpoint_create(self.listenerConnection))
     }
 }
 

--- a/Sources/SecureXPC/Server/XPCMachServer.swift
+++ b/Sources/SecureXPC/Server/XPCMachServer.swift
@@ -243,10 +243,7 @@ extension XPCMachServer {
         
         // Login item must be within the main app bundle's Contents/Library/LoginItems directory
         let pathComponents = loginItem.deletingLastPathComponent().pathComponents
-        guard pathComponents.count >= 3,
-              pathComponents[pathComponents.count - 1] == "LoginItems",
-              pathComponents[pathComponents.count - 2] == "Library",
-              pathComponents[pathComponents.count - 3] == "Contents" else {
+        guard pathComponents.count >= 3, pathComponents.suffix(3) == ["LoginItems", "Library", "Contents"] else {
             return false
         }
         

--- a/Sources/SecureXPC/Server/XPCMachServer.swift
+++ b/Sources/SecureXPC/Server/XPCMachServer.swift
@@ -164,7 +164,7 @@ extension XPCMachServer {
         return true
     }
     
-    internal static func _forThisBlessedHelperTool() throws -> XPCMachServer {
+    internal static func forThisBlessedHelperTool() throws -> XPCMachServer {
         // Determine mach service name using the launchd property list's MachServices entry
         let machServiceName: String
         let launchdData = try readEmbeddedPropertyList(sectionName: "__launchd_plist")
@@ -255,7 +255,7 @@ extension XPCMachServer {
         return true
     }
     
-    internal static func _forThisLoginItem() throws -> XPCMachServer {
+    internal static func forThisLoginItem() throws -> XPCMachServer {
         guard let teamIdentifier = try teamIdentifier() else {
             throw XPCError.misconfiguredServer(description: "A login item must have a team identifier in order to " +
                                                             "enable secure communication.")

--- a/Sources/SecureXPC/Server/XPCServer.swift
+++ b/Sources/SecureXPC/Server/XPCServer.swift
@@ -628,21 +628,21 @@ extension XPCServer {
         switch type {
             case .autoDetect:
                 if XPCServiceServer.isThisProcessAnXPCService {
-                    return try XPCServiceServer._forThisXPCService()
+                    return try XPCServiceServer.forThisXPCService()
                 } else if XPCMachServer.isThisProcessABlessedHelperTool {
-                    return try XPCMachServer._forThisBlessedHelperTool()
+                    return try XPCMachServer.forThisBlessedHelperTool()
                 } else if XPCMachServer.isThisProcessALoginItem {
-                    return try XPCMachServer._forThisLoginItem()
+                    return try XPCMachServer.forThisLoginItem()
                 } else {
                     throw XPCError.misconfiguredServer(description: "Unable to auto-detect what type of XPC server " +
                                                                     "this is. Please provide an explicit type.")
                 }
             case .xpcService:
-                return try XPCServiceServer._forThisXPCService()
+                return try XPCServiceServer.forThisXPCService()
             case .blessedHelperTool:
-                return try XPCMachServer._forThisBlessedHelperTool()
+                return try XPCMachServer.forThisBlessedHelperTool()
             case .loginItem:
-                return try XPCMachServer._forThisLoginItem()
+                return try XPCMachServer.forThisLoginItem()
             case .machService(let name, let clientRequirements):
                 let messageAcceptor = SecRequirementsMessageAcceptor(clientRequirements)
                 return try XPCMachServer.getXPCMachServer(named: name, messageAcceptor: messageAcceptor)

--- a/Sources/SecureXPC/Server/XPCServer.swift
+++ b/Sources/SecureXPC/Server/XPCServer.swift
@@ -476,9 +476,7 @@ public class XPCServer {
     /// Retrieve an endpoint for this XPC server and then use ``XPCClient/forEndpoint(_:)`` to create a client.
     ///
     /// Endpoints can be sent across an XPC connection.
-    ///
-    /// XPC services do not have endpoints, while XPC Mach services and anonymous servers both do.
-    public var endpoint: XPCServerEndpoint? {
+    public var endpoint: XPCServerEndpoint {
         fatalError("Abstract Property")
     }
 }

--- a/Sources/SecureXPC/Server/XPCServer.swift
+++ b/Sources/SecureXPC/Server/XPCServer.swift
@@ -130,7 +130,7 @@ public class XPCServer {
     public var handlerQueue = DispatchQueue.global()
     
     /// Used to determine whether an incoming XPC message from a client should be processed and handed off to a registered route.
-    internal let messageAcceptor: MessageAcceptor
+    internal var messageAcceptor: MessageAcceptor
     
     internal init(messageAcceptor: MessageAcceptor) {
         self.messageAcceptor = messageAcceptor
@@ -555,6 +555,11 @@ extension XPCServer {
         /// specify this service's name and client requirements.
         case autoDetect
         /// A process that is an [XPC service](https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/CreatingXPCServices.html)
+        ///
+        /// By default the returned server will accept incoming requests from any client without any _explicit_ security requirements; however, macOS itself only
+        /// allows the containing application to make such incoming requests. If you retrieve the ``XPCServer/endpoint`` for an XPC service, this will
+        /// upgrade the security requirements of the server and require all requests to be from the same containing application bundle. If this XPC service has a
+        /// Team ID then incoming requests will also need to be from processes with the same Team ID.
         case xpcService
         /// A process that is a helper tool installed with
         /// [`SMJobBless`](https://developer.apple.com/documentation/servicemanagement/1431078-smjobbless).

--- a/Sources/SecureXPC/Server/XPCServer.swift
+++ b/Sources/SecureXPC/Server/XPCServer.swift
@@ -500,7 +500,7 @@ extension XPCServer {
     /// Creates a new anonymous server that accepts requests from the same process it's running in.
     ///
     /// Only a client created from an anonymous server's endpoint can communicate with that server. Do this by retrieving the server's
-    /// ``XPCNonBlockingServer/endpoint`` and then creating a client with it:
+    /// ``XPCServer/endpoint`` and then creating a client with it:
     /// ```swift
     /// let server = XPCServer.makeAnonymous()
     /// let client = XPCClient.fromEndpoint(server.endpoint)
@@ -617,7 +617,7 @@ extension XPCServer {
     
     /// Returns the XPC server for this process.
     ///
-    /// The type of server returned and its request acceptance behavior will depend on what type of ``ProcessType`` this server was created for.
+    /// The request acceptance behavior of the returned service will depend on what type of ``ProcessType`` this server was created for.
     ///
     /// > Important: No requests will be processed until ``startAndBlock()`` or ``XPCNonBlockingServer/start()`` is called.
     ///

--- a/Sources/SecureXPC/Server/XPCServer.swift
+++ b/Sources/SecureXPC/Server/XPCServer.swift
@@ -10,41 +10,28 @@ import Foundation
 /// An XPC server to receive requests from and send responses to an ``XPCClient``.
 ///
 /// ### Retrieving a Server
-/// There are two different types of services you can retrieve a server for: XPC services and XPC Mach services. If you're uncertain which type of service you're
-/// using, it's likely an XPC service.
-///
-/// Anonymous servers can also be created which do not correspond to an XPC service or XPC Mach service.
-///
-/// #### XPC services
-/// These are helper tools which ship as part of your app and only your app can communicate with.
-///
-/// To retrieve a server for an XPC service:
+/// Typically this is as easy as:
 /// ```swift
-/// let server = try XPCServer.forThisXPCService()
+/// let server = try XPCServer.forThisProcess()
 /// ```
 ///
-/// #### XPC Mach services
-/// Launch Agents, Launch Daemons, helper tools installed with
-/// [`SMJobBless`](https://developer.apple.com/documentation/servicemanagement/1431078-smjobbless), and login items installed with
+/// This will always work for any
+/// [XPC service](https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/CreatingXPCServices.html).
+/// XPC services are helper tools which ship as part of your app and only your app can communicate with.
+///
+/// In most cases helper tools installed with
+/// [`SMJobBless`](https://developer.apple.com/documentation/servicemanagement/1431078-smjobbless) and login items installed with
 /// [`SMLoginItemSetEnabled`](https://developer.apple.com/documentation/servicemanagement/1501557-smloginitemsetenabled) can
-/// optionally communicate over XPC by using Mach services.
+/// also be retrieved in the same way. See ``ProcessType/blessedHelperTool`` and ``ProcessType/loginItem`` for details.
 ///
-/// In most cases, a server can be auto-configured using ``XPCServer/forThisBlessedHelperTool()`` for a helper tool installed with `SMJobBless`:
-/// ```swift
-/// let server = try XPCServer.forThisBlessedHelperTool()
-/// ```
-///
-/// Similarly, a server can be auto-configured using ``XPCServer/forThisLoginItem()`` for a login item installed with `SMLoginItemSetEnabled`.
-///
-/// For Launch Agents, Launch Daemons, more advanced `SMJobBless` and `SMLoginItemSetEnabled` configurations, as well as other cases it is
-/// necessary both to the specify the name of the service as well its security requirements. See
-/// ``XPCServer/forThisMachService(named:clientRequirements:)`` for an example and details.
+/// For Launch Agents, Launch Daemons, and any other types of services an `XPCServer` can be retrieved by explicitly creating a
+/// ``ProcessType/machService(name:clientRequirements:)`` instance.
 ///
 /// #### Anonymous servers
 /// An anonymous server can be created by any macOS program. Use cases for making one include:
 ///  - Allowing two processes which are not XPC services to communicate over XPC with each other. This is done by having one of those processes make an
-///    anonymous server and send its ``XPCNonBlockingServer/endpoint`` to an XPC Mach service. The other process then needs to retrieve that
-///    endpoint from the XPC Mach service and create a client using ``XPCClient/forEndpoint(_:)``.
+///    anonymous server and send its ``XPCServer/endpoint`` to an XPC Mach service. The other process then needs to retrieve that endpoint from the XPC
+///    Mach service and create a client using ``XPCClient/forEndpoint(_:)``.
 ///  - Testing code that would otherwise run as part of an XPC Mach service without needing to install a helper tool. However, note that this code won't run as root.
 ///
 /// ### Registering & Handling Routes
@@ -87,17 +74,20 @@ import Foundation
 /// server.startAndBlock()
 /// ```
 ///
-/// Returned server instances which conform to ``XPCNonBlockingServer`` can also be started in a non-blocking manner:
+/// Server instances which conform to ``XPCNonBlockingServer`` can also be started in a non-blocking manner:
 /// ```swift
 /// server.start()
 /// ```
 ///
+/// ### Requirements Checking
+/// On macOS 11 and later, requirement checking uses publicly documented APIs. On older versions of macOS, the private undocumented API
+/// `void xpc_connection_get_audit_token(xpc_connection_t, audit_token_t *)` will be used.  When requests are not accepted, if an error
+/// handler has been set then it is called with ``XPCError/insecure``.
+///
 /// ## Topics
 /// ### Retrieving a Server
-/// - ``forThisXPCService()`` 
-/// - ``forThisBlessedHelperTool()``
-/// - ``forThisLoginItem()``
-/// - ``forThisMachService(named:clientRequirements:)``
+/// - ``forThisProcess(ofType:)``
+/// - ``ProcessType``
 /// - ``makeAnonymous()``
 /// - ``makeAnonymous(clientRequirements:)``
 /// ### Registering Async Routes
@@ -123,7 +113,7 @@ import Foundation
 /// - ``XPCNonBlockingServer/start()``
 /// ### Server State
 /// - ``connectionDescriptor``
-/// - ``XPCNonBlockingServer/endpoint``
+/// - ``endpoint``
 public class XPCServer {
     
     /// The queue used to run synchronous handlers associated with registered routes.
@@ -482,6 +472,15 @@ public class XPCServer {
     public var connectionDescriptor: XPCConnectionDescriptor {
         fatalError("Abstract Property")
     }
+    
+    /// Retrieve an endpoint for this XPC server and then use ``XPCClient/forEndpoint(_:)`` to create a client.
+    ///
+    /// Endpoints can be sent across an XPC connection.
+    ///
+    /// XPC services do not have endpoints, while XPC Mach services and anonymous servers both do.
+    public var endpoint: XPCServerEndpoint? {
+        fatalError("Abstract Property")
+    }
 }
 
 // MARK: public server protocols
@@ -492,36 +491,12 @@ public class XPCServer {
 public protocol XPCNonBlockingServer {
     /// Begins processing requests received by this XPC server.
     func start()
-    
-    /// Retrieve an endpoint for this XPC server and then use ``XPCClient/forEndpoint(_:)`` to create a client.
-    ///
-    /// Endpoints can be sent across an XPC connection.
-    var endpoint: XPCServerEndpoint { get }
-    
-    // Internal implementation note: `endpoint` is part of the `XPCNonBlockingServer` protocol instead of `XPCServer` as
-    // `XPCServiceServer` can't have an endpoint created for it.
-    
-    // From a technical perspective this is because endpoints are only created from connection listeners, which an XPC
-    // service doesn't expose (incoming connections are simply passed to the handler provided to `xpc_main(...)`. From a
-    // security point of view, it makes sense that it's not possible to create an endpoint for an XPC service because
-    // they're designed to only allow communication between the main app and .xpc bundles contained within the same main
-    // app's bundle. As such there's no valid use case for creating such an endpoint.
 }
 
 // MARK: public factories
 
 // Contains all of the `static` code that provides the entry points to retrieving an `XPCServer` instance.
 extension XPCServer {
-    /// Provides a server for this XPC service.
-    ///
-    /// > Important: No requests will be processed until ``startAndBlock()`` is called.
-    ///
-    /// - Throws: ``XPCError/notXPCService`` if the caller is not an XPC service.
-    /// - Returns: A server instance configured for this XPC service.
-    public static func forThisXPCService() throws -> XPCServer {
-        try XPCServiceServer._forThisXPCService()
-    }
-    
     /// Creates a new anonymous server that accepts requests from the same process it's running in.
     ///
     /// Only a client created from an anonymous server's endpoint can communicate with that server. Do this by retrieving the server's
@@ -541,9 +516,9 @@ extension XPCServer {
 
     /// Creates a new anonymous server that accepts requests from clients which meet the security requirements.
     ///
-    /// Only a client created from an anonymous server's endpoint can communicate with that server. Retrieve the ``XPCNonBlockingServer/endpoint``
-    /// and send it across an existing XPC connection. Because other processes on the system can talk to an anonymous server, when making a server it is
-    /// required that you specifiy the
+    /// Only a client created from an anonymous server's endpoint can communicate with that server. Retrieve the ``XPCServer/endpoint`` and send it
+    /// across an existing XPC connection. Because other processes on the system can talk to an anonymous server, when making a server it is required that you
+    /// specifiy the
     /// [requirements](https://developer.apple.com/library/archive/documentation/Security/Conceptual/CodeSigningGuide/RequirementLang/RequirementLang.html)
     /// of any connecting clients:
     /// ```swift
@@ -561,11 +536,6 @@ extension XPCServer {
     ///
     /// > Important: No requests will be processed until ``XPCNonBlockingServer/start()`` or ``startAndBlock()`` is called.
     ///
-    /// ## Requirements Checking
-    /// On macOS 11 and later, requirement checking uses publicly documented APIs. On older versions of macOS, the private undocumented API
-    /// `void xpc_connection_get_audit_token(xpc_connection_t, audit_token_t *)` will be used.  When requests are not accepted, if an
-    /// error handler has been set then it is called with ``XPCError/insecure``.
-    ///
     /// > Note: If you only need this server to be communicated with by clients running in the same process, use ``makeAnonymous()`` instead.
     ///
     /// - Parameters:
@@ -574,88 +544,109 @@ extension XPCServer {
         XPCAnonymousServer(messageAcceptor: SecRequirementsMessageAcceptor(clientRequirements))
     }
     
-    /// Provides a server for this helper tool if it was installed with
-    /// [`SMJobBless`](https://developer.apple.com/documentation/servicemanagement/1431078-smjobbless).
-    ///
-    /// To successfully call this function the following requirements must be met:
-    ///   - The launchd property list embedded in this helper tool must have exactly one entry for its `MachServices` dictionary
-    ///   - The info property list embedded in this helper tool must have at least one element in its
-    ///   [`SMAuthorizedClients`](https://developer.apple.com/documentation/bundleresources/information_property_list/smauthorizedclients)
-    ///   array
-    ///   - Every element in the `SMAuthorizedClients` array must be a valid security requirement
-    ///     - To be valid, it must be creatable by
-    ///     [`SecRequirementCreateWithString`](https://developer.apple.com/documentation/security/1394522-secrequirementcreatewithstring)
-    ///
-    /// Incoming requests will be accepted from clients that meet _any_ of the `SMAuthorizedClients` requirements.
-    ///
-    /// > Important: No requests will be processed until ``startAndBlock()`` or ``XPCNonBlockingServer/start()`` is called.
-    ///
-    /// - Throws: ``XPCError/misconfiguredBlessedHelperTool(description:)`` if the configuration does not match this function's
-    ///           requirements.
-    /// - Returns: A server instance configured with the embedded property list entries.
-    public static func forThisBlessedHelperTool() throws -> XPCServer & XPCNonBlockingServer {
-        try XPCMachServer._forThisBlessedHelperTool()
+    /// The type of process an ``XPCServer`` should be retrieved for.
+    public enum ProcessType {
+        /// Auto-detects what type of server to create for this process.
+        ///
+        /// Auto-detection currently supports:
+        /// - ``xpcService``
+        /// - ``blessedHelperTool``
+        /// - ``loginItem``
+        ///
+        /// For any other type such as Launch Agent or Launch Daemon, ``machService(name:clientRequirements:)`` must be used to explicitly
+        /// specify this service's name and client requirements.
+        case autoDetect
+        /// A process that is an [XPC service](https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/CreatingXPCServices.html)
+        case xpcService
+        /// A process that is a helper tool installed with
+        /// [`SMJobBless`](https://developer.apple.com/documentation/servicemanagement/1431078-smjobbless).
+        ///
+        /// For a server to be automatically created for this process the following requirements must be met:
+        ///   - The launchd property list embedded in this helper tool must have exactly one entry for its `MachServices` dictionary
+        ///   - The info property list embedded in this helper tool must have at least one element in its
+        ///   [`SMAuthorizedClients`](https://developer.apple.com/documentation/bundleresources/information_property_list/smauthorizedclients)
+        ///   array
+        ///   - Every element in the `SMAuthorizedClients` array must be a valid security requirement
+        ///     - To be valid, it must be creatable by
+        ///     [`SecRequirementCreateWithString`](https://developer.apple.com/documentation/security/1394522-secrequirementcreatewithstring)
+        ///
+        /// The returned server will accept incoming requests from clients that meet _any_ of the `SMAuthorizedClients` requirements.
+        ///
+        /// If this process does not meet these requirements or you would like to have different acceptance criteria for incoming requests then a
+        /// ``machService(name:clientRequirements:)`` may be used instead to explicitly specify this service's name and client requirements.
+        case blessedHelperTool
+        
+        /// A process that is a login item enabled with
+        /// [`SMLoginItemSetEnabled`](https://developer.apple.com/documentation/servicemanagement/1501557-smloginitemsetenabled).
+        ///
+        /// For a server to be automatically created for this process the following requirements must be met:
+        ///   - This bundle for this process must have a team identifier
+        ///   - If this is a sandboxed login item, the
+        ///     [`com.apple.security.application-groups`](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_security_application-groups)
+        ///     entitlement must be present and one of the application groups must have the same team identifier as this login item
+        ///
+        /// The returned server will accept incoming requests from the main app or helper tools contained within the main app bundle. Additionally they must have
+        /// the same team identifier as this login item.
+        ///
+        /// If this process does not meet these requirements or you would like to have different acceptance criteria for incoming requests then a
+        /// ``machService(name:clientRequirements:)`` may be used instead to explicitly specify this service's name and client requirements.
+        case loginItem
+        
+        /// A process that is running as an XPC Mach service.
+        ///
+        /// Use this case to explicitly provide a service name and define the security requirements for connecting clients. This allows for retrieving a server for
+        /// any Launch Daemons and Launch Agents as well as customizing client requirements for process types with built-in support.
+        ///
+        /// Because many processes on the system can talk to an XPC Mach service, when retrieving a server it is required that you specifiy the
+        /// [code signing requirements](https://developer.apple.com/library/archive/documentation/Security/Conceptual/CodeSigningGuide/RequirementLang/RequirementLang.html)
+        /// of any connecting clients:
+        /// ```swift
+        /// let reqString = "identifier \"com.example.AuthorizedClient\" and certificate leaf[subject.OU] = \"4L0ZG128MM\""
+        /// var requirement: SecRequirement?
+        /// if SecRequirementCreateWithString(reqString as CFString,
+        ///                                   SecCSFlags(),
+        ///                                   &requirement) == errSecSuccess,
+        ///   let requirement = requirement {
+        ///     let server = XPCServer.forThisProcess(ofType: .machService(name: "com.example.service",
+        ///                                                                clientRequirements: [requirement]))
+        ///    <# configure and start server #>
+        /// }
+        /// ```
+        case machService(name: String, clientRequirements: [SecRequirement])
     }
     
-    /// Provides a server for this login item installed with
-    /// [`SMLoginItemSetEnabled`](https://developer.apple.com/documentation/servicemanagement/1501557-smloginitemsetenabled).
+    /// Returns the XPC server for this process.
     ///
-    /// This function may successfully be called by both sandboxed and non-sandboxed login items. If this is a sandboxed login item, the
-    /// [`com.apple.security.application-groups`](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_security_application-groups)
-    /// entitlement must be present and one of the application groups must have the same team identifier as this login item. Both sandboxed and non-sandboxed
-    /// apps must have a team identifier.
-    ///
-    /// Incoming requests will only be accepted from the main app or helper tools contained within the main app bundle. Additionally they must have the same team
-    /// identifier as this login item.
+    /// The type of server returned and its request acceptance behavior will depend on what type of ``ProcessType`` this server was created for.
     ///
     /// > Important: No requests will be processed until ``startAndBlock()`` or ``XPCNonBlockingServer/start()`` is called.
     ///
-    /// - Returns: A server instance configured to communicate with its main containing app.
-    public static func forThisLoginItem() throws -> XPCServer & XPCNonBlockingServer {
-        try XPCMachServer._forThisLoginItem()
-    }
-
-    /// Provides a server for this XPC Mach service that accepts requests from clients which meet the security requirements.
-    ///
-    /// For the provided server to function properly, the caller must be an XPC Mach service.
-    ///
-    /// Because many processes on the system can talk to an XPC Mach service, when retrieving a server it is required that you specifiy the
-    /// [requirements](https://developer.apple.com/library/archive/documentation/Security/Conceptual/CodeSigningGuide/RequirementLang/RequirementLang.html)
-    /// of any connecting clients:
-    /// ```swift
-    /// let reqString = "identifier \"com.example.AuthorizedClient\" and certificate leaf[subject.OU] = \"4L0ZG128MM\""
-    /// var requirement: SecRequirement?
-    /// if SecRequirementCreateWithString(reqString as CFString,
-    ///                                   SecCSFlags(),
-    ///                                   &requirement) == errSecSuccess,
-    ///   let requirement = requirement {
-    ///     let server = XPCServer.forThisMachService(named: "com.example.service",
-    ///                                               clientRequirements: [requirement])
-    ///
-    ///    <# configure and start server #>
-    /// }
-    /// ```
-    /// > Important: No requests will be processed until ``startAndBlock()`` or ``XPCNonBlockingServer/start()`` is called.
-    ///
-    /// ## Requirements Checking
-    ///
-    /// SecureXPC requires that a server for an XPC Mach service provide code signing requirements which define which clients are allowed to talk to it.
-    ///
-    /// On macOS 11 and later, requirement checking uses publicly documented APIs. On older versions of macOS, the private undocumented API
-    /// `void xpc_connection_get_audit_token(xpc_connection_t, audit_token_t *)` will be used. When requests are not accepted, if an
-    /// error handler has been set then it is called with ``XPCError/insecure``.
-    ///
-    /// - Parameters:
-    ///   - named: The name of the Mach service this server should bind to.
-    ///   - clientRequirements: If a request is received from a client, it will only be processed if it meets one (or more) of these requirements.
-    /// - Throws: ``XPCError/conflictingClientRequirements`` if a server for this named service has previously been retrieved with different client
-    ///           requirements.
-    public static func forThisMachService(
-        named machServiceName: String,
-        clientRequirements: [SecRequirement]
-    ) throws -> XPCServer & XPCNonBlockingServer {
-        try XPCMachServer.getXPCMachServer(named: machServiceName,
-                                           messageAcceptor: SecRequirementsMessageAcceptor(clientRequirements))
+    /// By default this function will attempt to auto-detect which type of server this process represents. If this server's type cannot be detected then an error will be
+    /// thrown. To resolve this, explicitly provide a ``ProcessType`` and use ``ProcessType/machService(name:clientRequirements:)`` for any
+    /// configurations which do not have built-in support.
+    public static func forThisProcess(ofType type: ProcessType = .autoDetect) throws -> XPCServer {
+        switch type {
+            case .autoDetect:
+                if XPCServiceServer.isThisProcessAnXPCService {
+                    return try XPCServiceServer._forThisXPCService()
+                } else if XPCMachServer.isThisProcessABlessedHelperTool {
+                    return try XPCMachServer._forThisBlessedHelperTool()
+                } else if XPCMachServer.isThisProcessALoginItem {
+                    return try XPCMachServer._forThisLoginItem()
+                } else {
+                    throw XPCError.misconfiguredServer(description: "Unable to auto-detect what type of XPC server " +
+                                                                    "this is. Please provide an explicit type.")
+                }
+            case .xpcService:
+                return try XPCServiceServer._forThisXPCService()
+            case .blessedHelperTool:
+                return try XPCMachServer._forThisBlessedHelperTool()
+            case .loginItem:
+                return try XPCMachServer._forThisLoginItem()
+            case .machService(let name, let clientRequirements):
+                let messageAcceptor = SecRequirementsMessageAcceptor(clientRequirements)
+                return try XPCMachServer.getXPCMachServer(named: name, messageAcceptor: messageAcceptor)
+        }
     }
 }
 

--- a/Sources/SecureXPC/Server/XPCServer.swift
+++ b/Sources/SecureXPC/Server/XPCServer.swift
@@ -17,7 +17,7 @@ import Foundation
 ///
 /// This will always work for any
 /// [XPC service](https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/CreatingXPCServices.html).
-/// XPC services are helper tools which ship as part of your app and only your app can communicate with.
+/// XPC services are helper tools which ship as part of an app and that by default only that app can communicate with.
 ///
 /// In most cases helper tools installed with
 /// [`SMJobBless`](https://developer.apple.com/documentation/servicemanagement/1431078-smjobbless) and login items installed with
@@ -81,7 +81,7 @@ import Foundation
 ///
 /// ### Requirements Checking
 /// On macOS 11 and later, requirement checking uses publicly documented APIs. On older versions of macOS, the private undocumented API
-/// `void xpc_connection_get_audit_token(xpc_connection_t, audit_token_t *)` will be used.  When requests are not accepted, if an error
+/// `void xpc_connection_get_audit_token(xpc_connection_t, audit_token_t *)` is used.  When requests are not accepted, if an error
 /// handler has been set then it is called with ``XPCError/insecure``.
 ///
 /// ## Topics

--- a/Sources/SecureXPC/Server/XPCServiceServer.swift
+++ b/Sources/SecureXPC/Server/XPCServiceServer.swift
@@ -19,7 +19,7 @@ internal class XPCServiceServer: XPCServer {
     
 	private static let service = XPCServiceServer(messageAcceptor: AlwaysAcceptingMessageAcceptor())
     
-    internal static func _forThisXPCService() throws -> XPCServiceServer {
+    internal static func forThisXPCService() throws -> XPCServiceServer {
         // An XPC service's package type must be equal to "XPC!", see Apple's documentation for details
         // https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/CreatingXPCServices.html#//apple_ref/doc/uid/10000172i-SW6-SW6
         

--- a/Sources/SecureXPC/Server/XPCServiceServer.swift
+++ b/Sources/SecureXPC/Server/XPCServiceServer.swift
@@ -21,21 +21,20 @@ internal class XPCServiceServer: XPCServer {
     
     /// Whether this server has been started.
     private var started = false
-    /// The serial queue used when to handle requets for an endpoint
+    /// The serial queue used for handling retrieving an `endpoint`
     private let endpointQueue = DispatchQueue(label: String(describing: XPCServiceServer.self))
     /// Receives new incoming connections via the endpoint
     private var anonymousListenerConnection: xpc_connection_t?
     /// Connections received for the anonymous listener connection while the server is not started
     private var pendingConnections = [xpc_connection_t]()
-    
-    
+        
     internal static func forThisXPCService() throws -> XPCServiceServer {
         // An XPC service's package type must be equal to "XPC!", see Apple's documentation for details
         // https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/CreatingXPCServices.html#//apple_ref/doc/uid/10000172i-SW6-SW6
         
         guard mainBundlePackageInfo().packageType == "XPC!" else {
             throw XPCError.misconfiguredServer(description: "An XPC service's CFBundlePackageType value must be XPC!")
-       }
+        }
 
         if Bundle.main.bundleIdentifier == nil {
             throw XPCError.misconfiguredServer(description: "An XPC service must have a CFBundleIdentifier")

--- a/Sources/SecureXPC/Server/XPCServiceServer.swift
+++ b/Sources/SecureXPC/Server/XPCServiceServer.swift
@@ -67,12 +67,11 @@ internal class XPCServiceServer: XPCServer {
     }
     
     public override var endpoint: XPCServerEndpoint? {
-        // An `XPCServiceServer` can't have an endpoint created for it. From a technical perspective this is because
-        // endpoints are only created from connection listeners, which an XPC service doesn't expose (incoming
-        // connections are simply passed to the handler provided to `xpc_main(...)`. From a security point of view, it
-        // makes sense that it's not possible to create an endpoint for an XPC service because they're designed to only
-        // allow communication between the main app and .xpc bundles contained within the same main app's bundle. As
-        // such there's no valid use case for creating such an endpoint.
+        // There's seemingly no way to create an endpoint for an XPC service using the XPC C API. This is because
+        // endpoints are only created from connection listeners, which an XPC service doesn't expose — incoming
+        // connections are simply passed to the handler provided to `xpc_main(...)`. Specifically the documentation for
+        // xpc_main says:
+        //   This function will set up your service bundle's listener connection and manage it automatically.
         nil
     }
 }

--- a/Sources/SecureXPC/XPCCommon.swift
+++ b/Sources/SecureXPC/XPCCommon.swift
@@ -140,3 +140,15 @@ func readEntitlement(name: String) throws -> CFTypeRef? {
     
     return entitlement
 }
+
+/// The team identifier for this process or `nil` if there isn't one.
+func teamIdentifier() throws -> String? {
+    var info: CFDictionary?
+    let flags = SecCSFlags(rawValue: kSecCSSigningInformation)
+    let status = SecCodeCopySigningInformation(try SecStaticCodeCopySelf(), flags, &info)
+    guard status == errSecSuccess, let info = info as NSDictionary? else {
+        throw XPCError.internalFailure(description: "SecCodeCopySigningInformation failed with status: \(status)")
+    }
+
+    return info[kSecCodeInfoTeamIdentifier] as? String
+}

--- a/Sources/SecureXPC/XPCError.swift
+++ b/Sources/SecureXPC/XPCError.swift
@@ -45,27 +45,12 @@ public enum XPCError: Error, Codable {
     ///
     /// The first associated value is the route's name. The second is a descriptive error message.
     case routeMismatch(routeName:[String], description: String)
-    /// The caller is not a blessed helper tool or its property list configuration is not compatible with ``XPCServer/forThisBlessedHelperTool()``.
-    ///
-    /// The associated string is a descriptive error message.
-    case misconfiguredBlessedHelperTool(description: String)
     /// A server already exists for this named XPC Mach service and therefore another server can't be returned with different client requirements.
     case conflictingClientRequirements
-    /// The caller is not an XPC service.
+    /// This process's configuration prevents an ``XPCServer`` being retrieved for it.
     ///
-    /// This may mean there is a configuration issue. Alternatively it could be the caller is an XPC Mach service, in which case use
-    /// ``XPCServer/forThisMachService(named:clientRequirements:)`` instead.
-    case notXPCService
-    /// The caller is a misconfigured XPC service.
-    ///
-    /// The associated string is a descriptive error message.
-    case misconfiguredXPCService(description: String)
-    /// The caller is not a login item installed with
-    /// [`SMLoginItemSetEnabled`](https://developer.apple.com/documentation/servicemanagement/1501557-smloginitemsetenabled)
-    /// or its configuration is not compatible with ``XPCServer/forThisLoginItem()``.
-    ///
-    /// The associated string is a descriptive error message.
-    case misconfiguredLoginItem(description: String)
+    /// The associated value describes why it could not be retrieved.
+    case misconfiguredServer(description: String)
     /// An error thrown by a handler registered with a ``XPCServer`` route when processing a client's request.
     ///
     /// The associated value represents, and possibly contains, the error.

--- a/Sources/SecureXPC/XPCServerEndpoint.swift
+++ b/Sources/SecureXPC/XPCServerEndpoint.swift
@@ -9,8 +9,8 @@ import Foundation
 
 /// An endpoint is used to create clients which can communicate with their associated server.
 ///
-/// Endpoints are retrieved from a server's ``XPCNonBlockingServer/endpoint`` property. They can be used in the same process or sent across an existing
-/// XPC connection.
+/// Endpoints are retrieved from a server's ``XPCServer/endpoint`` property. They can be used in the same process or sent across an existing XPC
+/// connection.
 ///
 /// > Warning: While ``XPCServerEndpoint`` conforms to `Codable` it can only be encoded and decoded by the `SecureXPC` framework.
 public struct XPCServerEndpoint {
@@ -19,11 +19,6 @@ public struct XPCServerEndpoint {
     
     // The underlying XPC C API endpoint needed to create connections to the listener connection it came from
     internal let endpoint: xpc_endpoint_t
-
-    internal init(connectionDescriptor: XPCConnectionDescriptor, endpoint: xpc_endpoint_t) {
-        self.connectionDescriptor = connectionDescriptor
-        self.endpoint = endpoint
-    }
 }
 
 extension XPCServerEndpoint: Hashable {

--- a/Sources/SecureXPC/XPCServerEndpoint.swift
+++ b/Sources/SecureXPC/XPCServerEndpoint.swift
@@ -14,6 +14,9 @@ import Foundation
 ///
 /// > Warning: While ``XPCServerEndpoint`` conforms to `Codable` it can only be encoded and decoded by the `SecureXPC` framework.
 public struct XPCServerEndpoint {
+    // Private implementation note: The connection descriptor may not represent the _true_ connection type in the case
+    // of an XPCServiceServer which for its endpoint makes use of an anonymous connection. SecureXPC intentionally
+    // represents this an an `xpcService` connection type as it better represents how SecureXPC behaves for the user.
     /// The type of connections serviced by the ``XPCServer`` which created this endpoint.
     public let connectionDescriptor: XPCConnectionDescriptor
     

--- a/Tests/SecureXPCTests/Client & Server/XPCServer Creation.swift
+++ b/Tests/SecureXPCTests/Client & Server/XPCServer Creation.swift
@@ -20,29 +20,29 @@ final class XPCServerCreationTests: XCTestCase {
     
     func testFailToRetrieveServicesServer() {
         do {
-            _ = try XPCServer.forThisXPCService()
-            XCTFail("No error was thrown. \(XPCError.notXPCService) should have been thrown.")
-        } catch XPCError.notXPCService {
+            _ = try XPCServer.forThisProcess(ofType: .xpcService)
+            XCTFail("No error was thrown. XPCError.misconfiguredServer should have been thrown.")
+        } catch XPCError.misconfiguredServer(_) {
             // Expected behavior
         } catch {
-            XCTFail("Unexpected error thrown. \(XPCError.notXPCService) should have been thrown.")
+            XCTFail("Unexpected error thrown. XPCError.misconfiguredServer should have been thrown.")
         }
     }
     
     func testFailToRetrievedBlessedHelperToolServer() {
         do {
-            _ = try XPCServer.forThisBlessedHelperTool()
-            XCTFail("No error was thrown. XPCError.misconfiguredBlessedHelperTool should have been thrown.")
-        } catch XPCError.misconfiguredBlessedHelperTool(_) {
+            _ = try XPCServer.forThisProcess(ofType: .blessedHelperTool)
+            XCTFail("No error was thrown. XPCError.misconfiguredServer should have been thrown.")
+        } catch XPCError.misconfiguredServer(_) {
             // Expected behavior
         } catch {
-            XCTFail("Unexpected error thrown. XPCError.misconfiguredBlessedHelperTool should have been thrown.")
+            XCTFail("Unexpected error thrown. XPCError.misconfiguredServer should have been thrown.")
         }
     }
     
     // Expectation: server can be created without throwing
     func testRetrieveMachServerOnce() throws {
-        _ = try XPCServer.forThisMachService(named: "com.example.foo", clientRequirements: [])
+        _ = try XPCServer.forThisProcess(ofType: .machService(name: "com.example.foo", clientRequirements: []))
     }
     
     // Expectation: same server is successfully returned for the same name and the same requirements
@@ -57,8 +57,10 @@ final class XPCServerCreationTests: XCTestCase {
         let requirements2 = [requirement2!]
         
         // The same server instance should be returned each time
-        let server1 = try XPCServer.forThisMachService(named: "com.example.bar", clientRequirements: requirements1)
-        let server2 = try XPCServer.forThisMachService(named: "com.example.bar", clientRequirements: requirements2)
+        let server1 = try XPCServer.forThisProcess(ofType: .machService(name: "com.example.bar",
+                                                                        clientRequirements: requirements1))
+        let server2 = try XPCServer.forThisProcess(ofType: .machService(name: "com.example.bar",
+                                                                        clientRequirements: requirements2))
         XCTAssertIdentical(server1, server2)
     }
     
@@ -68,14 +70,16 @@ final class XPCServerCreationTests: XCTestCase {
         SecRequirementCreateWithString("identifier \"foo.bar\"" as CFString, [], &requirement)
         let requirements = [requirement!]
         
-        _ = try XPCServer.forThisMachService(named: "com.example.biz", clientRequirements: requirements)
+        _ = try XPCServer.forThisProcess(ofType: .machService(name: "com.example.biz",
+                                                              clientRequirements: requirements))
 
         var otherRequirement: SecRequirement?
         SecRequirementCreateWithString("identifier \"fizz.buzz\"" as CFString, [], &otherRequirement)
         let otherRequirements = [otherRequirement!]
         
         do {
-            _ = try XPCServer.forThisMachService(named: "com.example.biz", clientRequirements: otherRequirements)
+            _ = try XPCServer.forThisProcess(ofType: .machService(name: "com.example.biz",
+                                                                  clientRequirements: otherRequirements))
             XCTFail("No error was thrown. \(XPCError.conflictingClientRequirements) should have been thrown.")
         } catch XPCError.conflictingClientRequirements {
             // Expected behavior


### PR DESCRIPTION
This introduces full auto-detection for common server types. For clients, specifying the name of the service will still be needed, but the caller won't in most cases need to know whether they're calling an XPC service or an XPC Mach service.