### PR TITLE
Introduces `XPCClientRequirement` to replace use of `SecRequirement`

### DIFF
--- a/Sources/SecureXPC/SecureXPC.docc/SecureXPC.md
+++ b/Sources/SecureXPC/SecureXPC.docc/SecureXPC.md
@@ -80,6 +80,7 @@ See ``XPCClient`` for more on how to retrieve a client and send requests.
 - ``XPCClient``
 - ``XPCServer``
 - ``XPCNonBlockingServer``
+- ``XPCClientRequirement``
 - ``XPCServerEndpoint``
 - ``XPCConnectionDescriptor``
 

--- a/Sources/SecureXPC/Server/XPCClientRequirement.swift
+++ b/Sources/SecureXPC/Server/XPCClientRequirement.swift
@@ -1,0 +1,95 @@
+//
+//  ClientRequirement.swift
+//  SecureXPC
+//
+//  Created by Josh Kaplan on 2022-07-04
+//
+
+import Foundation
+
+/// Determines whether a client's request should be routed to a request handler.
+public indirect enum XPCClientRequirement {
+    /// The requesting client must satisfy the specified code signing security requirement.
+    case secRequirement(SecRequirement)
+    
+    /// The requesting client must have the specified team identifier.
+    case teamIdentifier(String)
+    
+    /// The requesting client must have the same team identifier as this server.
+    ///
+    /// If this server does not have a team identifier, then this always evaluates to false.
+    case sameTeamIdentifier
+    
+    /// The requesting client must be within the same parent app bundle as this server.
+    ///
+    /// If this server is not part of an app bundle, then this always evaluates to false.
+    case sameAppBundle
+    
+    /// The requesting client must satisfy the designated requirement of the parent app bundle.
+    ///
+    /// If this server has no parent app bundle, then this always evaluates to false.
+    case parentAppDesignatedRequirement
+    
+    /// The requesting client must be running in the same process as this server.
+    case sameProcess
+    
+    /// The requesting client must satisfy both requirements.
+    case and(XPCClientRequirement, XPCClientRequirement)
+    
+    /// The requesting client must satisfy at least one of the requirements.
+    case or(XPCClientRequirement, XPCClientRequirement)
+    
+    internal var messageAcceptor: MessageAcceptor {
+        get throws {
+            switch self {
+                case .secRequirement(let requirement):
+                    return SecRequirementsMessageAcceptor([requirement])
+                case .teamIdentifier(let teamIdentifier):
+                    return try SecRequirementsMessageAcceptor(forTeamIdentifier: teamIdentifier)
+                case .sameTeamIdentifier:
+                    guard let teamID = try teamIdentifierForThisProcess() else {
+                        return NeverAcceptingMessageAcceptor()
+                    }
+                    
+                    return try SecRequirementsMessageAcceptor(forTeamIdentifier: teamID)
+                case .sameAppBundle:
+                    guard let parentBundleURL = try parentAppBundleURL() else {
+                        return NeverAcceptingMessageAcceptor()
+                    }
+                    
+                    return ParentBundleMessageAcceptor(parentBundleURL: parentBundleURL)
+                case .parentAppDesignatedRequirement:
+                    guard let parentBundleURL = try parentAppBundleURL() else {
+                        return NeverAcceptingMessageAcceptor()
+                    }
+                    
+                    var parentCode: SecStaticCode?
+                    var parentRequirement: SecRequirement?
+                    guard SecStaticCodeCreateWithPath(parentBundleURL as CFURL, [], &parentCode) == errSecSuccess,
+                          let parentCode = parentCode,
+                          SecCodeCopyDesignatedRequirement(parentCode, [], &parentRequirement) == errSecSuccess,
+                          let parentRequirement = parentRequirement else {
+                        return NeverAcceptingMessageAcceptor()
+                    }
+                    
+                    return SecRequirementsMessageAcceptor([parentRequirement])
+                case .sameProcess:
+                    return SameProcessMessageAcceptor()
+                case .and(let rhs, let lhs):
+                    return AndMessageAcceptor(lhs: try lhs.messageAcceptor, rhs: try rhs.messageAcceptor)
+                case .or(let rhs, let lhs):
+                    return OrMessageAcceptor(lhs: try lhs.messageAcceptor, rhs: try rhs.messageAcceptor)
+            }
+        }
+    }
+}
+
+private func parentAppBundleURL() throws -> URL? {
+    let components = Bundle.main.bundleURL.pathComponents
+    guard let contentsIndex = components.lastIndex(of: "Contents"),
+          components[components.index(before: contentsIndex)].hasSuffix(".app") else {
+        return nil
+    }
+    
+    return URL(fileURLWithPath: "/" + components[1..<contentsIndex].joined(separator: "/"))
+}

--- a/Sources/SecureXPC/Server/XPCMachServer.swift
+++ b/Sources/SecureXPC/Server/XPCMachServer.swift
@@ -350,7 +350,7 @@ extension XPCMachServer {
         // were the desired use case for this launch agent then in most cases an XPC service would be a better fit. If a
         // launch agent is being used it's reasonable to default to allowing requests from outside of the app bundle as
         // long as it's from the same team identifier.
-        guard let teamIdentifier = try teamIdentifier() else {
+        guard let teamIdentifier = try teamIdentifierForThisProcess() else {
             throw XPCError.misconfiguredServer(description: "A launch agent must have a team identifier in order to " +
                                                             "enable secure communication.")
         }
@@ -378,7 +378,7 @@ extension XPCMachServer {
     }
     
     internal static func forThisLoginItem() throws -> XPCMachServer {
-        guard let teamIdentifier = try teamIdentifier() else {
+        guard let teamIdentifier = try teamIdentifierForThisProcess() else {
             throw XPCError.misconfiguredServer(description: "A login item must have a team identifier in order to " +
                                                             "enable secure communication.")
         }

--- a/Sources/SecureXPC/Server/XPCServer.swift
+++ b/Sources/SecureXPC/Server/XPCServer.swift
@@ -91,11 +91,6 @@ import Foundation
 /// server.start()
 /// ```
 ///
-/// ### Requirements Checking
-/// On macOS 11 and later, requirement checking uses publicly documented APIs. On older versions of macOS, the private undocumented API
-/// `void xpc_connection_get_audit_token(xpc_connection_t, audit_token_t *)` is used.  When requests are not accepted, if an error
-/// handler has been set then it is called with ``XPCError/insecure``.
-///
 /// ## Topics
 /// ### Retrieving a Server
 /// - ``forThisProcess(ofType:)``

--- a/Sources/SecureXPC/Server/XPCServiceServer.swift
+++ b/Sources/SecureXPC/Server/XPCServiceServer.swift
@@ -127,7 +127,7 @@ internal class XPCServiceServer: XPCServer {
                                                        .deletingLastPathComponent() // XPCServices
                                                        .deletingLastPathComponent() // Contents
             let parentBundleAcceptor = ParentBundleMessageAcceptor(parentBundleURL: parentBundleURL)
-            if let teamID = try? teamIdentifier(),
+            if let teamID = try? teamIdentifierForThisProcess(),
                let teamIDAcceptor = try? SecRequirementsMessageAcceptor(forTeamIdentifier: teamID) {
                 self.messageAcceptor = AndMessageAcceptor(lhs: teamIDAcceptor, rhs: parentBundleAcceptor)
             } else {

--- a/Sources/SecureXPC/XPCCommon.swift
+++ b/Sources/SecureXPC/XPCCommon.swift
@@ -142,7 +142,7 @@ func readEntitlement(name: String) throws -> CFTypeRef? {
 }
 
 /// The team identifier for this process or `nil` if there isn't one.
-func teamIdentifier() throws -> String? {
+func teamIdentifierForThisProcess() throws -> String? {
     var info: CFDictionary?
     let flags = SecCSFlags(rawValue: kSecCSSigningInformation)
     let status = SecCodeCopySigningInformation(try SecStaticCodeCopySelf(), flags, &info)


### PR DESCRIPTION
Now API users of SecureXPC can more easily express custom client requirements that go beyond just ones represented by `SecRequirement`. Also very common `SecRequirement` cases such as team id and a parent's designated requirement can be specified without having to actually hand roll one.

This PR intentionally doesn't rework the internals of the server implementations to make use of this, but my intention is to follow up a future PR with such changes.

Tests were slightly updated to support this change and all tests pass.