### PR TITLE
Adds namespacing to `XPCRoute`, adds `serverIdentity` to `XPCClient`

### DIFF
--- a/Sources/SecureXPC/Client/XPCClient.swift
+++ b/Sources/SecureXPC/Client/XPCClient.swift
@@ -126,6 +126,9 @@ import Foundation
 /// - ``XPCSequentialResponseHandler``
 /// ### Client Information
 /// - ``connectionDescriptor``
+/// ### Server Information
+/// - ``serverIdentity``
+/// - ``serverIdentity(_:)``
 public class XPCClient {
     
     // MARK: Public factories
@@ -678,6 +681,71 @@ public class XPCClient {
     /// Creates and returns a connection for the service represented by this client.
     internal func createConnection() throws -> xpc_connection_t {
         fatalError("Abstract Method")
+    }
+    
+    // MARK: server identity
+    
+    /// A representation of the server's running program.
+    ///
+    /// The returned `SecCode` instance is provided by macOS itself and cannot be misrepresented (intentionally or otherwise) by the server.
+    ///
+    /// > Note: Accessing this property  involves cross-process communication with the server and is therefore subject to all of the same error conditions as making
+    /// a `send` or `sendMessage` call.
+    @available(macOS 10.15.0, *)
+    public var serverIdentity: SecCode {
+        get async throws {
+            try await withUnsafeThrowingContinuation { continuation in
+                self.serverIdentity { (response: Result<SecCode, XPCError>) -> Void in
+                    switch response {
+                        case .success(let identity):
+                            continuation.resume(returning: identity)
+                        case .failure(let error):
+                            continuation.resume(throwing: error)
+                    }
+                }
+            }
+        }
+    }
+    
+    /// Provides a representation of the server's running program to the handler.
+    ///
+    /// The provided `SecCode` instance comes from macOS itself and cannot be misrepresented (intentionally or otherwise) by the server.
+    ///
+    /// > Note: Calling this function involves cross-process communication with the server and is therefore subject to all of the same error conditions as making a
+    /// `send` or `sendMessage` call.
+    public func serverIdentity(_ handler: @escaping XPCResponseHandler<SecCode>) {
+        // Get the connection or inform the handler of failure and return
+        let connection: xpc_connection_t
+        do {
+            connection = try getConnection()
+        } catch {
+            handler(.failure(XPCError.asXPCError(error: error)))
+            return
+        }
+        
+        // Create request
+        let request: Request
+        do {
+            request = try Request(route: PackageInternalRoutes.noopRoute.route)
+        } catch {
+            handler(.failure(XPCError.asXPCError(error: error)))
+            return
+        }
+        
+        // Async send the request over XPC
+        xpc_connection_send_message_with_reply(connection, request.dictionary, nil) { reply in
+            if xpc_get_type(reply) == XPC_TYPE_ERROR {
+                handler(.failure(XPCError.fromXPCObject(reply)))
+                return
+            }
+            
+            // It doesn't matter what the reply actually contains, we just need it to determine server identity
+            guard let serverIdentity = SecCodeCreateWithXPCConnection(connection, andMessage: reply) else {
+                handler(.failure(XPCError.internalFailure(description: "Unable to get server's SecCode")))
+                return
+            }
+            handler(.success(serverIdentity))
+        }
     }
 }
 

--- a/Sources/SecureXPC/Client/XPCClient.swift
+++ b/Sources/SecureXPC/Client/XPCClient.swift
@@ -695,13 +695,8 @@ public class XPCClient {
     public var serverIdentity: SecCode {
         get async throws {
             try await withUnsafeThrowingContinuation { continuation in
-                self.serverIdentity { (response: Result<SecCode, XPCError>) -> Void in
-                    switch response {
-                        case .success(let identity):
-                            continuation.resume(returning: identity)
-                        case .failure(let error):
-                            continuation.resume(throwing: error)
-                    }
+                self.serverIdentity { response in
+                    continuation.resume(with: response)
                 }
             }
         }

--- a/Sources/SecureXPC/PackageInternalRoutes.swift
+++ b/Sources/SecureXPC/PackageInternalRoutes.swift
@@ -1,0 +1,16 @@
+//
+//  PackageInternalRoutes.swift
+//  SecureXPC
+//
+//  Created by Josh Kaplan on 2022-07-06
+//
+
+import Foundation
+
+enum PackageInternalRoutes {
+    
+    /// A route which does nothing on the server when called.
+    ///
+    /// This is useful because the client can use this to know the server exists and get information about it such as its `SecCode`.
+    static let noopRoute = XPCRoute.named("noop").packageInternal
+}

--- a/Sources/SecureXPC/Server/XPCServer.swift
+++ b/Sources/SecureXPC/Server/XPCServer.swift
@@ -141,6 +141,7 @@ public class XPCServer {
     
     internal init(clientRequirement: XPCClientRequirement) {
         self.clientRequirement = clientRequirement
+        self.registerPackageInternalRoutes()
     }
     
     // MARK: Route registration
@@ -154,6 +155,11 @@ public class XPCServer {
         if let _ = self.routes.updateValue(handler, forKey: route) {
             fatalError("Route \(route.pathComponents) is already registered")
         }
+    }
+    
+    /// Registers package internal routes.
+    private func registerPackageInternalRoutes() {
+        self.registerRoute(PackageInternalRoutes.noopRoute) { }
     }
         
     /// Registers a route for a request without a message that does not receive a reply.

--- a/Tests/SecureXPCTests/Client & Server/Server Identity Tests.swift
+++ b/Tests/SecureXPCTests/Client & Server/Server Identity Tests.swift
@@ -1,0 +1,24 @@
+//
+//  Server Identity Tests.swift
+//  SecureXPC
+//
+//  Created by Josh Kaplan on 2022-07-07
+//
+
+import Foundation
+import XCTest
+import SecureXPC
+
+class ServerIdentityTests: XCTestCase {
+    func testGetServerIdentity() async throws {
+        let server = XPCServer.makeAnonymous()
+        let client = XPCClient.forEndpoint(server.endpoint)
+        server.start()
+        
+        // Since the server is running in the same process as this test, the identity should be the same as this one
+        var currentIdentity: SecCode?
+        SecCodeCopySelf([], &currentIdentity)
+        let serverIdentity = try await client.serverIdentity
+        XCTAssertEqual(serverIdentity, currentIdentity!)
+    }
+}


### PR DESCRIPTION
Routes are now namespace allowing for the framework to have its own routes that cannot conflict with routes provided by end users of the API.

This functionality is then used to introduce a noop route which the client calls in order to obtain the identity of the server. This is essentially the client's equivalent of `XPCRequestContext`.

The intention is to build upon this PR with another one that allows the client to enforce a security requirement on the server.