### PR TITLE
Moves around some code within `XPClient`

### DIFF
--- a/Sources/SecureXPC/Client/XPCEndpointClient.swift
+++ b/Sources/SecureXPC/Client/XPCEndpointClient.swift
@@ -12,7 +12,6 @@ import Foundation
 /// In the case of this package, this is the only way to communicate with an `XPCAnonymousServer`. It is also how `XPCServiceServer` and
 /// `XPCMachServer` are communicated with when accessed via an ``XPCServer/endpoint`` returned for them.
 internal class XPCEndpointClient: XPCClient {
-    
     private let endpoint: XPCServerEndpoint
 
     internal init(endpoint: XPCServerEndpoint, serverRequirement: XPCServerRequirement) {

--- a/Sources/SecureXPC/Client/XPCServerIdentity.swift
+++ b/Sources/SecureXPC/Client/XPCServerIdentity.swift
@@ -26,6 +26,6 @@ public struct XPCServerIdentity {
     /// The effective group id of the server process.
     public let effectiveGroupID: gid_t
     
-    /// It's intentional that the process id (PID) of the server process is not exposed since misuse of it can result in security vulnerabilities
+    /// It's intentional that the process id (PID) of the server process is not exposed since misuse of it can result in security vulnerabilities.
     internal let processID: pid_t
 }


### PR DESCRIPTION
There aren't any actual code changes here, it just moves the static factory code into an extension so that it's structured the same way as `XPCServer`