### PR TITLE
Addresses misc feedback

### DIFF
--- a/Sources/SecureXPC/Server/XPCMachServer.swift
+++ b/Sources/SecureXPC/Server/XPCMachServer.swift
@@ -198,7 +198,7 @@ extension XPCMachServer {
             }
             
             if let currentRequirement = clientRequirement {
-                clientRequirement = .or(currentRequirement, .secRequirement(requirement))
+                clientRequirement = currentRequirement || .secRequirement(requirement)
             } else {
                 clientRequirement = .secRequirement(requirement)
             }
@@ -383,7 +383,7 @@ extension XPCMachServer {
             The bundle identifier is missing; login items must have one.
             """)
         }
-        let clientRequirement = try XPCClientRequirement.and(.teamIdentifier(teamIdentifier), .sameParentBundle)
+        let clientRequirement: XPCClientRequirement = try .teamIdentifier(teamIdentifier) || .sameParentBundle
         
         return try getXPCMachServer(named: bundleID, clientRequirement: clientRequirement)
     }

--- a/Sources/SecureXPC/Server/XPCServiceServer.swift
+++ b/Sources/SecureXPC/Server/XPCServiceServer.swift
@@ -124,7 +124,7 @@ internal class XPCServiceServer: XPCServer {
             // bundle requirement should always succeed because as part of creating an XPCServiceServer a check is
             // performance that this process is located within a Contents/XPCServices directory.
             if let teamIDRequirement = try? XPCClientRequirement.sameTeamIdentifier {
-                self.clientRequirement = .and(try! .sameParentBundle, teamIDRequirement)
+                self.clientRequirement = try! .sameParentBundle && teamIDRequirement
             } else {
                 self.clientRequirement = try! .sameParentBundle
             }

--- a/Sources/SecureXPC/XPCCommon.swift
+++ b/Sources/SecureXPC/XPCCommon.swift
@@ -68,12 +68,11 @@ func SecCodeCopyPath(_ code: SecCode) -> URL? {
     }
     
     var path: CFURL?
-    guard Security.SecCodeCopyPath(staticCode, SecCSFlags(), &path) == errSecSuccess,
-          let path = (path as URL?)?.standardized else {
+    guard Security.SecCodeCopyPath(staticCode, SecCSFlags(), &path) == errSecSuccess else {
         return nil
     }
     
-    return path
+    return (path as URL?)?.standardized
 }
 
 /// Encapsulates the undocumented function `void xpc_connection_get_audit_token(xpc_connection_t, audit_token_t *)`.


### PR DESCRIPTION
Addresses feedback for several recent PRs, not including the property wrapper one. There's also a change in here to make `XPCServer` be consistent with `XPCClient` in making it clear *what* type of requirement is needed (now that are two different kinds).