### PR TITLE
Splits `XPCServer.forThisProcess(...)` into separate functions

### DIFF
--- a/Sources/SecureXPC/Client/XPCClient.swift
+++ b/Sources/SecureXPC/Client/XPCClient.swift
@@ -122,7 +122,7 @@ import Foundation
 /// ## Topics
 /// ### Retrieving a Client
 /// - ``forXPCService(named:)``
-/// - ``forXPCMachService(named:withServerRequirement:)``
+/// - ``forMachService(named:withServerRequirement:)``
 /// - ``forEndpoint(_:withServerRequirement:)``
 /// ### Sending Requests with Async
 /// - ``send(to:)-5b1ar``
@@ -706,7 +706,7 @@ extension XPCClient {
     /// An XPC service is a helper tool which ships as part of your app and only your app can communicate with.
     ///
     /// In order for this client to be able to communicate with the XPC service, the service itself must retrieve and configure an ``XPCServer`` by calling
-    /// ``XPCServer/forThisProcess(ofType:)``.
+    /// ``XPCServer/forThisXPCService()``.
     ///
     /// > Note: It is a fatal error to provide a name for an XPC service which does not correspond to an XPC service contained within this bundle.
     ///
@@ -756,7 +756,7 @@ extension XPCClient {
     /// - Launch Daemons
     ///
     /// In order for this client to be able to communicate with the XPC Mach service, the service itself must retrieve and configure an ``XPCServer`` by calling
-    /// ``XPCServer/forThisProcess(ofType:)``.
+    /// ``XPCServer/forMachService(withCriteria:)``.
     ///
     /// > Note: Client retrieval always succeeds regardless of whether or not the XPC Mach service exists.
     ///
@@ -767,7 +767,7 @@ extension XPCClient {
     ///                         server with the same team identifier so long as this client has a team identifier; if this client does not have a team identifier
     ///                         then any server will be trusted.
     /// - Returns: A client configured to communicate with the named service.
-    public static func forXPCMachService(
+    public static func forMachService(
         named machServiceName: String,
         withServerRequirement serverRequirement: XPCServerRequirement = .sameTeamIdentifierIfPresent
     ) -> XPCClient {

--- a/Sources/SecureXPC/SecureXPC.docc/SecureXPC.md
+++ b/Sources/SecureXPC/SecureXPC.docc/SecureXPC.md
@@ -39,7 +39,7 @@ See ``XPCRoute`` to learn more about how to create routes.
 In one program retrieve a server, register those routes, and then start the server:
 ```swift
     ...
-    let server = XPCServer.forThisProcess()
+    let server = <# server retrieval here #>
     server.registerRoute(route, handler: bedazzle)
     server.startAndBlock()
 }

--- a/Sources/SecureXPC/Server/MachServiceCriteria.swift
+++ b/Sources/SecureXPC/Server/MachServiceCriteria.swift
@@ -1,0 +1,568 @@
+//
+//  MachServiceCriteria.swift
+//  SecureXPC
+//
+//  Created by Josh Kaplan on 2022-07-17
+//
+
+import Foundation
+
+public extension XPCServer {
+    /// The criteria used to retrieve an ``XPCServer`` via ``XPCServer/forMachService(withCriteria:)``.
+    ///
+    /// Use this struct to:
+    /// - create requirements for a Mach service without built-in support
+    /// - specify the name of the Mach service when this process offers multiple Mach services
+    /// - customize the client requirement for a type with built-in support 
+    ///
+    /// It's always preferable when built-in support for a type exists to use the corresponding factory function such as
+    ///  ``forBlessedHelperTool(named:withClientRequirement:)`` because it will ensure the calling process actually *is* a blessed helper tool
+    /// and if a name is provided that the name is one of the Mach services listed in its launchd property list. This can be helpful in resolving configuration issues
+    /// and for quickly finding typos. This is also convenient when specifying the name of a Mach service because there are multiple offered and want to use the
+    /// default client requirement.
+    ///
+    /// ## Topics
+    /// ### Explicit Configuration
+    /// - ``init(machServiceName:clientRequirement:)``
+    /// ### Factory Functions
+    /// - ``forBlessedHelperTool(named:withClientRequirement:)``
+    /// - ``forDaemon(named:withClientRequirement:)``
+    /// - ``forAgent(named:withClientRequirement:)``
+    /// - ``forLoginItem(withClientRequirement:)``
+    struct MachServiceCriteria {
+        /// The name of the Mach service to be retrieved.
+        internal let machServiceName: String
+        /// The requirement for clients in order to be allowed to communicate with this Mach service.
+        internal let clientRequirement: XPCClientRequirement
+        
+        /// Explicitly specified criteria for a Mach service.
+        ///
+        /// - Parameters:
+        ///   - machServiceName: The name of the service to be retrieved; no validation is performed.
+        ///   - clientRequirement: The requirement for clients in order to be allowed to communicate with this Mach service.
+        public init(machServiceName: String, clientRequirement: XPCClientRequirement) {
+            self.machServiceName = machServiceName
+            self.clientRequirement = clientRequirement
+        }
+        
+        /// Criteria for this process, automatically configured.
+        ///
+        /// Auto-configuration currently supports the following when exactly one unique `MachServices` entry is present:
+        /// - ``forBlessedHelperTool(named:withClientRequirement:)``
+        /// - ``forAgent(named:withClientRequirement:)``
+        /// - ``forDaemon(named:withClientRequirement:)``
+        ///
+        /// Addtionally ``forLoginItem(withClientRequirement:)`` can always be auto-configured.
+        ///
+        /// When auto configuration is not possible, criteria can be explicitly specified via ``init(machServiceName:clientRequirement:)``.
+        internal static func autoConfigure() throws -> MachServiceCriteria {
+            if validateThisProcessIsABlessedHelperTool().didSucceed {
+                return try _forBlessedHelperTool()
+            } else if validateThisProcessIsALoginItem().didSucceed {
+                return try _forLoginItem()
+            } else if validateThisProcessIsAnSMAppServiceDaemon().didSucceed {
+                return try _forDaemon()
+            } else if validateThisProcessIsAnSMAppServiceAgent().didSucceed {
+                return try _forAgent()
+            } else {
+                throw XPCError.misconfiguredServer(description: """
+                Unable to determine what type of process this Mach service belongs to. Criteria will need to be \
+                explicitly provided.
+                """)
+            }
+        }
+        
+        // Common logic used by blessed helper tool, agent, & daemon
+        private static func createCriteria(
+            named name: String?,
+            machServices: Set<String>,
+            withClientRequirement requirement: XPCClientRequirement?,
+            defaultClientRequirementCreator: () throws -> XPCClientRequirement
+        ) throws -> MachServiceCriteria {
+            let machServiceName: String
+            if let name = name {
+                guard machServices.contains(name) else {
+                    throw XPCError.misconfiguredServer(description: """
+                    There is no MachServices key for value: \(name)
+                    Available keys:
+                    \(machServices.joined(separator: "\n"))
+                    """)
+                }
+                machServiceName = name
+            } else {
+                guard machServices.count == 1, let inferredName = machServices.first else {
+                    throw XPCError.misconfiguredServer(description: """
+                    In order to not provide a name, the MachServices dictionary must have exactly one entry. Entries
+                    present:
+                    \(machServices.joined(separator: "\n"))
+                    """)
+                }
+                machServiceName = inferredName
+            }
+            
+            let clientRequirement = try requirement ?? defaultClientRequirementCreator()
+            
+            return MachServiceCriteria(machServiceName: machServiceName, clientRequirement: clientRequirement)
+        }
+        
+        /// Criteria for a helper tool installed with
+        /// [`SMJobBless`](https://developer.apple.com/documentation/servicemanagement/1431078-smjobbless).
+        ///
+        /// - Parameters:
+        ///   - name: The name of the Mach service to be created. If there is exactly one `MachServices` entry in the embedded launchd property list then
+        ///           the name does not need to be provided and can be automatically inferred.
+        ///   - requirement: The requirement for the client. If no requirement is provided this will be automatically generated using the [`SMAuthorizedClients`](https://developer.apple.com/documentation/bundleresources/information_property_list/smauthorizedclients)
+        ///                  array in the embedded info property list. Each element in the array must be a valid security requirement, meaning it must be
+        ///                  creatable by
+        ///     [`SecRequirementCreateWithString`](https://developer.apple.com/documentation/security/1394522-secrequirementcreatewithstring).
+        ///                  The resulting client requirement accept incoming requests from clients that meet _any_ of the `SMAuthorizedClients`
+        ///                  requirements.
+        /// - Returns: Criteria for a Mach service belonging to a helper tool installed with `SMJobBless`.
+        public static func forBlessedHelperTool(
+            named name: String? = nil,
+            withClientRequirement requirement: XPCClientRequirement? = nil
+        ) throws -> MachServiceCriteria {
+            try validateThisProcessIsABlessedHelperTool().throwIfFailure()
+            
+            return try _forBlessedHelperTool(named: name, withClientRequirement: requirement)
+        }
+        
+        private static func _forBlessedHelperTool(
+            named name: String? = nil,
+            withClientRequirement requirement: XPCClientRequirement? = nil
+        ) throws -> MachServiceCriteria {
+            try createCriteria(named: name,
+                               machServices: try blessedHelperToolMachServices(),
+                               withClientRequirement: requirement,
+                               defaultClientRequirementCreator: blessedHelperToolClientRequirements)
+        }
+        
+        /// Criteria for a launch daemon registered via
+        /// [`SMAppService.daemon(plistName:)`](https://developer.apple.com/documentation/servicemanagement/smappservice/3945410-daemon).
+        ///
+        /// This does **not** include launch daemons manually registered via a property list in `/Library/LaunchDaemons/`.
+        ///
+        /// - Parameters:
+        ///   - name: The name of the Mach service to be created. If there is exactly one `MachServices` entry across all bundled property lists which
+        ///           reference the `BundleProgram` corresponding to this executable then the name does not need to be provided and can be
+        ///           automatically inferred.
+        ///   - requirement: The requirement for the client. If no requirement is provided, one will be automatically generated to meet the designated
+        ///                  requirement of the containing app (meaning in most cases only the containing app's requests will be accepted).
+        /// - Returns: Criteria for a Mach service belonging to a daemon registered via `SMAppService.daemon(plistName:)`.
+        @available(macOS 13.0, *)
+        public static func forDaemon(
+            named name: String? = nil,
+            withClientRequirement requirement: XPCClientRequirement? = nil
+        ) throws -> MachServiceCriteria {
+            try validateThisProcessIsAnSMAppServiceDaemon().throwIfFailure()
+            
+            return try _forDaemon(named: name, withClientRequirement: requirement)
+        }
+        
+        private static func _forDaemon(
+            named name: String? = nil,
+            withClientRequirement requirement: XPCClientRequirement? = nil
+        ) throws -> MachServiceCriteria {
+            try createCriteria(named: name,
+                               machServices: try agentOrDaemonMachServices(directory: .daemon),
+                               withClientRequirement: requirement) {
+                // Use the parent's designated requirement as the client criteria. Considering the considerable
+                // privilege escalation potential this intentionally takes a more restricted approach than what is taken
+                // for a login item or agent.
+                try .parentDesignatedRequirement
+            }
+        }
+        
+        /// Criteria for a launch agent registered via
+        /// [`SMAppService.agent(plistName:)`](https://developer.apple.com/documentation/servicemanagement/smappservice/3945409-agent).
+        ///
+        /// This does **not** include launch agent manually registered via a property list in `~/Library/LaunchAgents` or
+        /// `/Library/LaunchAgents`.
+        ///
+        /// - Parameters:
+        ///   - name: The name of the Mach service to be created. If there is exactly one `MachServices` entry across all bundled property lists which
+        ///           reference the `BundleProgram` corresponding to this executable then the name does not need to be provided and can be
+        ///           automatically inferred.
+        ///   - requirement: The requirement for the client.  If none is provided then clients will be trusted if they have the same team identifier as
+        ///                  this agent; if this agent has no team identifier an error will be thrown.
+        /// - Returns: Criteria for a Mach service belonging to a daemon registered via `SMAppService.agent(plistName:)`.
+        @available(macOS 13.0, *)
+        public static func forAgent(
+            named name: String? = nil,
+            withClientRequirement requirement: XPCClientRequirement? = nil
+        ) throws -> MachServiceCriteria {
+            try validateThisProcessIsAnSMAppServiceDaemon().throwIfFailure()
+            
+            return try _forAgent(named: name, withClientRequirement: requirement)
+        }
+        
+        private static func _forAgent(
+            named name: String? = nil,
+            withClientRequirement requirement: XPCClientRequirement? = nil
+        ) throws -> MachServiceCriteria {
+            try createCriteria(named: name,
+                               machServices: try agentOrDaemonMachServices(directory: .agent),
+                               withClientRequirement: requirement) {
+                // Use the team identifier as the client criteria. An alternative approach would be to use the parent's
+                // designated requirement or restrict to within the parent's app bundle, but if either of those were the
+                // desired use case for this launch agent then in most cases an XPC service would be a better fit. If a
+                // launch agent is being used it's reasonable to default to allowing requests from outside of the app
+                // bundle as long as it's from the same team identifier.
+                try .sameTeamIdentifier
+            }
+        }
+        
+        /// Criteria for a login item enabled with
+        /// [`SMLoginItemSetEnabled`](https://developer.apple.com/documentation/servicemanagement/1501557-smloginitemsetenabled).
+        ///
+        /// If this is a sandboxed login item, the
+        ///     [`com.apple.security.application-groups`](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_security_application-groups)
+        /// entitlement must be present and one of the application groups must have the same team identifier as this login item.
+        ///
+        /// - Parameter requirement: The requirement for the client. If none is provided then clients will be trusted if they have the same team identifier as
+        ///                          this login item (if this login item has a team identifier) and belong to the same parent app bundle.
+        /// - Returns: Criteria for a Mach service belonging to a login item enabled with `SMLoginItemSetEnabled`.
+        public static func forLoginItem(
+            withClientRequirement requirement: XPCClientRequirement? = nil
+        ) throws -> MachServiceCriteria {
+            try validateThisProcessIsALoginItem().throwIfFailure()
+            
+            return try _forLoginItem(withClientRequirement: requirement)
+        }
+        
+        private static func _forLoginItem(
+            withClientRequirement requirement: XPCClientRequirement? = nil
+        ) throws -> MachServiceCriteria {
+            try throwIfSandboxedAndThisLoginItemCannotCommunicateOverXPC()
+            
+            // From Apple's AppSandboxLoginItemXPCDemo:
+            // https://developer.apple.com/library/archive/samplecode/AppSandboxLoginItemXPCDemo/
+            //     LaunchServices implicitly registers a Mach service for the login item whose name is the same as the
+            //     login item's bundle identifier.
+            guard let bundleID = Bundle.main.bundleIdentifier else {
+                throw XPCError.misconfiguredServer(description: """
+                Login items must have a bundle identifier (CFBundleIdentifier).
+                """)
+            }
+            
+            let clientRequirement: XPCClientRequirement
+            if let requirement = requirement {
+                clientRequirement = requirement
+            } else {
+                if let sameTeamRequirement = try? XPCClientRequirement.sameTeamIdentifier {
+                    clientRequirement = try sameTeamRequirement && .sameParentBundle
+                } else {
+                    clientRequirement = try .sameParentBundle
+                }
+            }
+            
+            return MachServiceCriteria(machServiceName: bundleID, clientRequirement: clientRequirement)
+        }
+    }
+}
+
+// MARK: validation result
+
+private enum ValidationResult {
+    case success
+    case failure(String)
+    
+    var didSucceed: Bool {
+        switch self {
+            case .success:
+                return true
+            case .failure(_):
+                return false
+        }
+    }
+    
+    func throwIfFailure() throws {
+        switch self {
+            case .success:
+                break
+            case .failure(let description):
+                throw XPCError.misconfiguredServer(description: description)
+        }
+    }
+}
+
+// MARK: Blessed helper tool
+
+/// Read the property list embedded within this helper tool.
+///
+/// - Returns: The property list as data.
+private func readEmbeddedPropertyList(sectionName: String) throws -> Data {
+    // By passing in nil, this returns a handle for the dynamic shared object (shared library) for this helper tool
+    guard let handle = dlopen(nil, RTLD_LAZY) else {
+        throw XPCError.misconfiguredServer(description: "Could not read property list (handle not openable)")
+    }
+    defer { dlclose(handle) }
+    
+    guard let mhExecutePointer = dlsym(handle, MH_EXECUTE_SYM) else {
+        throw XPCError.misconfiguredServer(description: "Could not read property list (nil symbol pointer)")
+    }
+    let mhExecuteBoundPointer = mhExecutePointer.assumingMemoryBound(to: mach_header_64.self)
+
+    var size = UInt()
+    guard let section = getsectiondata(mhExecuteBoundPointer, "__TEXT", sectionName, &size) else {
+        throw XPCError.misconfiguredServer(description: "Missing property list section \(sectionName)")
+    }
+    
+    return Data(bytes: section, count: Int(size))
+}
+
+/// Validates this process is a valid blessed helper tool, intentionally not taking into account whether it has an XPC Mach service.
+private func validateThisProcessIsABlessedHelperTool() -> ValidationResult {
+    // Following comments describe what must be true for this to be a blessed (privileged) helper tool:
+
+    // Located in: /Library/PrivilegedHelperTools/
+    guard Bundle.main.bundleURL == URL(fileURLWithPath: "/Library/PrivilegedHelperTools") else {
+        return .failure("""
+        A blessed helper tool must be located in directory: /Library/PrivilegedHelperTools
+        Actual location: \(Bundle.main.bundleURL)
+        """)
+    }
+    
+    // Executable (not a bundle)
+    guard let executableURL = Bundle.main.executableURL,
+          let firstFourBytes = try? FileHandle(forReadingFrom: executableURL).readData(ofLength: 4),
+          firstFourBytes.count == 4 else {
+        return .failure("A blessed helper tool must be an executable file")
+    }
+    let magicValue = firstFourBytes.withUnsafeBytes { pointer in
+        pointer.load(fromByteOffset: 0, as: UInt32.self)
+    }
+    let machOMagicValues: Set<UInt32> = [MH_MAGIC, MH_CIGAM, MH_MAGIC_64, MH_CIGAM_64, FAT_MAGIC, FAT_CIGAM]
+    guard machOMagicValues.contains(magicValue) else {
+        return .failure("A blessed helper tool must be a Mach-O executable file")
+    }
+    
+    // Embedded __launchd_plist section that has a Label entry which matches this executable name
+    guard let launchdData = try? readEmbeddedPropertyList(sectionName: "__launchd_plist"),
+          let launchdPlist = try? PropertyListSerialization.propertyList(from: launchdData,
+                                                                         format: nil) as? [String : Any],
+          let label = launchdPlist["Label"] as? String,
+          executableURL.lastPathComponent == label else {
+        return .failure("""
+        A blessed helper tool have a Label entry in its embedded launchd property list with a value equal to the name
+        of its executable file
+        """)
+    }
+    
+    // Embedded __info_plist section with a SMAuthorizedClients entry
+    guard let infoData = try? readEmbeddedPropertyList(sectionName: "__info_plist"),
+          let infoPlist = try? PropertyListSerialization.propertyList(from: infoData, format: nil) as? [String : Any],
+          infoPlist.keys.contains("SMAuthorizedClients") else {
+        return .failure("A blessed helper tool have a SMAuthorizedClients entry in its embedded info property list")
+    }
+    
+    return .success
+}
+
+/// Extract the `MachServices` key values from the embedded launchd property list
+private func blessedHelperToolMachServices() throws -> Set<String> {
+    let data = try readEmbeddedPropertyList(sectionName: "__launchd_plist")
+    guard let propertyList = try PropertyListSerialization.propertyList(from: data, format: nil) as? NSDictionary else {
+        throw XPCError.misconfiguredServer(description: "No launchd property list is embedded in executable")
+    }
+    guard let machServices = propertyList["MachServices"] as? [String : Any] else {
+        throw XPCError.misconfiguredServer(description: "launchd property list missing MachServices key")
+    }
+    if machServices.isEmpty {
+        throw XPCError.misconfiguredServer(description: "MachServices has no entries")
+    }
+    
+    return Set<String>(machServices.keys)
+}
+
+/// Generate client requirements from the embedded info property list's `SMAuthorizedClients`
+private func blessedHelperToolClientRequirements() throws -> XPCClientRequirement {
+    // Read authorized clients
+    let data = try readEmbeddedPropertyList(sectionName: "__info_plist")
+    guard let propertyList = try PropertyListSerialization.propertyList(from: data, format: nil) as? NSDictionary else {
+        throw XPCError.misconfiguredServer(description: "No info property list is embedded in executable")
+    }
+    guard let authorizedClients = propertyList["SMAuthorizedClients"] as? [String] else {
+        throw XPCError.misconfiguredServer(description: "Info property list missing SMAuthorizedClients key")
+    }
+    
+    // Turn into client requirement
+    var clientRequirement: XPCClientRequirement? = nil
+    for client in authorizedClients {
+        var requirement: SecRequirement?
+        guard SecRequirementCreateWithString(client as CFString, SecCSFlags(), &requirement) == errSecSuccess,
+              let requirement = requirement else {
+            throw XPCError.misconfiguredServer(description: "Invalid SMAuthorizedClients requirement: \(client)")
+        }
+        
+        if let currentRequirement = clientRequirement {
+            clientRequirement = currentRequirement || .secRequirement(requirement)
+        } else {
+            clientRequirement = .secRequirement(requirement)
+        }
+    }
+    guard let clientRequirement = clientRequirement else {
+        throw XPCError.misconfiguredServer(description: "No requirements were generated from SMAuthorizedClients")
+    }
+    
+    return clientRequirement
+}
+
+// MARK: Login item
+
+private func validateThisProcessIsALoginItem() -> ValidationResult {
+    // Login item must be a bundle
+    let loginItem = Bundle.main.bundleURL
+    guard loginItem.pathExtension == "app" else {
+        return .failure("A login item must be an app bundle.")
+    }
+    
+    // Login item must be within the main bundle's Contents/Library/LoginItems directory
+    let pathComponents = loginItem.deletingLastPathComponent().pathComponents
+    guard pathComponents.count >= 3, pathComponents.suffix(3) == ["Contents", "Library", "LoginItems"] else {
+        return .failure("""
+        A login item must be located within its parent bundle's Contents/Library/LoginItems directory.
+        Path:\(Bundle.main.bundleURL)
+        """)
+    }
+    
+    return .success
+}
+
+/// If this process is sandboxed, then the login item *must* have an application group entitlement in order to enable XPC communication. (Non-sandboxed apps
+/// cannot have one as this entitlement only applies to the sandbox - it's not part of the hardened runtime.)
+private func throwIfSandboxedAndThisLoginItemCannotCommunicateOverXPC() throws {
+    guard try isSandboxed() else {
+        return
+    }
+    
+    let entitlementName = "com.apple.security.application-groups"
+    let entitlement = try readEntitlement(name: entitlementName)
+    guard let entitlement = entitlement else {
+        throw XPCError.misconfiguredServer(description: """
+        Application groups entitlement \(entitlementName) is missing, but must be present for a sandboxed login item \
+        to communicate over XPC.
+        """)
+    }
+    guard CFGetTypeID(entitlement) == CFArrayGetTypeID(), let entitlement = (entitlement as? NSArray) else {
+        throw XPCError.misconfiguredServer(description: """
+        Application groups entitlement \(entitlementName) must be an array of strings.
+        """)
+    }
+    let appGroups = try entitlement.map { (element: NSArray.Element) throws -> String in
+        guard let elementAsString = element as? String else {
+            throw XPCError.misconfiguredServer(description: """
+            Application groups entitlement \(entitlementName) must be an array of strings.
+            """)
+        }
+        
+        return elementAsString
+    }
+    
+    guard let teamIdentifier = try teamIdentifierForThisProcess() else {
+        throw XPCError.misconfiguredServer(description: """
+        A sandboxed login item must have a team identifier in order to communicate over XPC.
+        """)
+    }
+    
+    // From https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_security_application-groups
+    //     For macOS the format is: <team identifier>.<group name>
+    //
+    // So for XPC communication to succeed at least one app group must start with this login item's team identifier
+    // followed by a period.
+    if !appGroups.contains(where: { $0.starts(with: "\(teamIdentifier).") }) {
+        throw XPCError.misconfiguredServer(description: """
+        Application groups entitlement \(entitlementName) must contain at least one application group for team \
+        identifier \(teamIdentifier). Application groups:
+        \(appGroups.joined(separator: "\n"))
+        """)
+    }
+}
+
+// MARK: SMAppService daemon & agent
+
+private func parentAppURL() throws -> URL {
+    let components = Bundle.main.bundleURL.pathComponents
+    guard let contentsIndex = components.lastIndex(of: "Contents"),
+          components[components.index(before: contentsIndex)].hasSuffix(".app") else {
+        throw XPCError.misconfiguredServer(description: """
+        Parent bundle could not be found.
+        Path:\(Bundle.main.bundleURL)
+        """)
+    }
+    
+    return URL(fileURLWithPath: "/" + components[1..<contentsIndex].joined(separator: "/"))
+}
+
+private enum LibraryDirectory: String {
+    case daemon = "LaunchDaemons"
+    case agent = "LaunchAgents"
+}
+
+private func plistsForDaemonOrAgent(parentURL: URL, directory: LibraryDirectory) throws -> [[String : Any]] {
+    // For a daemon, from Apple:
+    //   The property list name must correspond to a property list in the calling app’s
+    //   Contents/Library/LaunchDaemons directory
+    //
+    // For an agent, from Apple:
+    //   The property list name must correspond to a property list in the calling app’s
+    //   Contents/Library/LaunchAgents directory.
+    guard let executableURL = Bundle.main.executableURL else {
+        throw XPCError.misconfiguredServer(description: "This process lacks an executable URL")
+    }
+    let plistDirectory = parentURL.appendingPathComponent("Contents", isDirectory: true)
+                                  .appendingPathComponent("Library", isDirectory: true)
+                                  .appendingPathComponent(directory.rawValue, isDirectory: true)
+    let plistDirectoryContents = try FileManager.default.contentsOfDirectory(at: plistDirectory,
+                                                                             includingPropertiesForKeys: nil)
+    let plistsData = plistDirectoryContents.compactMap { try? Data(contentsOf: $0) }
+    let plists = plistsData.compactMap {
+        try? PropertyListSerialization.propertyList(from: $0, format: nil) as? [String : Any]
+    }
+    let matchingPlists = plists.filter {
+        guard let bundleProgram = $0["BundleProgram"] as? String else {
+            return false
+        }
+        return URL(string: bundleProgram, relativeTo: parentURL)?.absoluteURL == executableURL
+    }
+    
+    return matchingPlists
+}
+
+private func agentOrDaemonMachServices(directory: LibraryDirectory) throws -> Set<String> {
+    let parentURL = try parentAppURL()
+    let plists = try plistsForDaemonOrAgent(parentURL: parentURL, directory: directory)
+    let serviceNames = Set<String>(plists.flatMap { ($0["MachServices"] as? [String : Any] ?? [:]).keys })
+    
+    if serviceNames.isEmpty {
+        throw XPCError.misconfiguredServer(description: "No MachServices entries")
+    }
+    
+    return serviceNames
+}
+
+private func validateThisProcessIsAnSMAppServiceDaemon() -> ValidationResult {
+    guard let parentURL = try? parentAppURL(),
+          let propertyLists = try? plistsForDaemonOrAgent(parentURL: parentURL, directory: .daemon),
+          !propertyLists.isEmpty else {
+        return .failure("""
+        An SMAppService daemon must have a property list within its parent bundle's Contents/Library/LaunchDaemons /
+        directory.
+        """)
+    }
+    
+    return .success
+}
+
+private func validateThisProcessIsAnSMAppServiceAgent() -> ValidationResult {
+    guard let parentURL = try? parentAppURL(),
+          let propertyLists = try? plistsForDaemonOrAgent(parentURL: parentURL, directory: .agent),
+          !propertyLists.isEmpty else {
+        return .failure("""
+        An SMAppService agent must have a property list within its parent bundle's Contents/Library/LaunchAgents /
+        directory.
+        """)
+    }
+    
+    return .success
+}

--- a/Sources/SecureXPC/Server/XPCClientRequirement.swift
+++ b/Sources/SecureXPC/Server/XPCClientRequirement.swift
@@ -13,9 +13,8 @@ import Foundation
 ///
 /// Use a client requirement to retrieve a customized `XPCServer` instance:
 /// ```swift
-/// let server = XPCServer.forThisProcess(ofType: .machService(
-///     name: "com.example.service",
-///     clientRequirement: try .sameTeamIdentifier))
+/// let server = try XPCServer.forMachService(withCriteria:
+///   .forLoginItem(withClientRequirement: try .parentDesignatedRequirement))
 /// ```
 ///
 /// Requirements can be combined with `||` as well as `&&`:

--- a/Sources/SecureXPC/Server/XPCMachServer.swift
+++ b/Sources/SecureXPC/Server/XPCMachServer.swift
@@ -23,15 +23,15 @@ internal class XPCMachServer: XPCServer {
     private var pendingConnections = [xpc_connection_t]()
     
     /// This should only ever be called from `getXPCMachServer(...)` so that client requirement invariants are upheld.
-    private init(machServiceName: String, clientRequirement: XPCClientRequirement) {
-        self.machServiceName = machServiceName
+    private init(criteria: MachServiceCriteria) {
+        self.machServiceName = criteria.machServiceName
         let listenerQueue = DispatchQueue(label: String(describing: XPCMachServer.self))
         // Attempts to bind to the Mach service. If this isn't actually a Mach service a EXC_BAD_INSTRUCTION will occur.
         self.listenerConnection = machServiceName.withCString { namePointer in
             xpc_connection_create_mach_service(namePointer, listenerQueue, UInt64(XPC_CONNECTION_MACH_SERVICE_LISTENER))
         }
         self.listenerQueue = listenerQueue
-        super.init(clientRequirement: clientRequirement)
+        super.init(clientRequirement: criteria.clientRequirement)
         
         // Configure listener for new connections, all received events are incoming client connections
         xpc_connection_set_event_handler(self.listenerConnection, { connection in
@@ -91,350 +91,31 @@ extension XPCMachServer {
     /// Prevents race conditions for creating and retrieving cached Mach servers
     private static let serialQueue = DispatchQueue(label: "XPCMachServer Retrieval Queue")
     
-    /// Returns a server with the provided name and an equivalent message acceptor OR throws an error if that's not possible.
+    /// Returns a server with the provided name and an equivalent client requirement OR throws an error if that's not possible.
     ///
     /// Decision tree:
     /// - If a server exists with that name:
-    ///   - If the message acceptors are equivalent, return the server.
+    ///   - If the client requirements are equivalent, return the server.
     ///   - Else, throw an error.
     /// - Else no server exists in the cache with the provided name, create one, store it in the cache, and return it.
     ///
     /// This behavior prevents ending up with two servers for the same named XPC Mach service.
-    internal static func getXPCMachServer(named machServiceName: String,
-                                          clientRequirement: XPCClientRequirement) throws -> XPCMachServer {
+    internal static func getXPCMachServer(criteria: MachServiceCriteria) throws -> XPCMachServer {
         // Force serial execution to prevent a race condition where multiple XPCMachServer instances for the same Mach
         // service name are created and returned
         try serialQueue.sync {
             let server: XPCMachServer
-            if let cachedServer = machServerCache[machServiceName] {
-                guard clientRequirement == cachedServer.clientRequirement else {
+            if let cachedServer = machServerCache[criteria.machServiceName] {
+                guard criteria.clientRequirement == cachedServer.clientRequirement else {
                     throw XPCError.conflictingClientRequirements
                 }
                 server = cachedServer
             } else {
-                server = XPCMachServer(machServiceName: machServiceName, clientRequirement: clientRequirement)
-                machServerCache[machServiceName] = server
+                server = XPCMachServer(criteria: criteria)
+                machServerCache[criteria.machServiceName] = server
             }
             
             return server
-        }
-    }
-    
-    // MARK: Blessed Helper Tool
-    
-    internal static var isThisProcessABlessedHelperTool: Bool {
-        // Following comments describe what must be true for this to be a blessed (privileged) helper tool:
-
-        // Located in: /Library/PrivilegedHelperTools/
-        guard Bundle.main.bundleURL == URL(fileURLWithPath: "/Library/PrivilegedHelperTools") else {
-            return false
-        }
-        
-        // Executable (not a bundle)
-        guard let executableURL = Bundle.main.executableURL,
-              let firstFourBytes = try? FileHandle(forReadingFrom: executableURL).readData(ofLength: 4),
-              firstFourBytes.count == 4 else {
-            return false
-        }
-        let magicValue = firstFourBytes.withUnsafeBytes { pointer in
-            pointer.load(fromByteOffset: 0, as: UInt32.self)
-        }
-        let machOMagicValues: Set<UInt32> = [MH_MAGIC, MH_CIGAM, MH_MAGIC_64, MH_CIGAM_64, FAT_MAGIC, FAT_CIGAM]
-        guard machOMagicValues.contains(magicValue) else {
-            return false
-        }
-        
-        // Embedded __launchd_plist section that has a Label entry which matches this executable name
-        guard let launchdData = try? readEmbeddedPropertyList(sectionName: "__launchd_plist"),
-              let launchdPlist = try? PropertyListSerialization.propertyList(from: launchdData,
-                                                                             format: nil) as? [String : Any],
-              let label = launchdPlist["Label"] as? String,
-              executableURL.lastPathComponent == label else {
-            return false
-        }
-        
-        // Embedded __info_plist section with a SMAuthorizedClients entry
-        guard let infoData = try? readEmbeddedPropertyList(sectionName: "__info_plist"),
-              let infoPlist = try? PropertyListSerialization.propertyList(from: infoData,
-                                                                          format: nil) as? [String : Any],
-              infoPlist.keys.contains("SMAuthorizedClients") else {
-            return false
-        }
-        
-        return true
-    }
-    
-    internal static func forThisBlessedHelperTool() throws -> XPCMachServer {
-        // Determine mach service name using the launchd property list's MachServices entry
-        let machServiceName: String
-        let launchdData = try readEmbeddedPropertyList(sectionName: "__launchd_plist")
-        let launchdPropertyList = try PropertyListSerialization.propertyList(
-            from: launchdData,
-            options: .mutableContainersAndLeaves,
-            format: nil) as? NSDictionary
-        if let machServices = launchdPropertyList?["MachServices"] as? [String : Any] {
-            if machServices.count == 1, let name = machServices.first?.key {
-                machServiceName = name
-            } else {
-                throw XPCError.misconfiguredServer(description: "MachServices dictionary must have exactly one entry")
-            }
-        } else {
-            throw XPCError.misconfiguredServer(description: "launchd property list missing MachServices key")
-        }
-
-        // Generate client requirements from info property list's SMAuthorizedClients
-        let infoData = try readEmbeddedPropertyList(sectionName: "__info_plist")
-        let infoPropertyList = try PropertyListSerialization.propertyList(from: infoData, format: nil) as? NSDictionary
-        guard let authorizedClients = infoPropertyList?["SMAuthorizedClients"] as? [String] else {
-            throw XPCError.misconfiguredServer(description: "Info property list missing SMAuthorizedClients key")
-        }
-        
-        var clientRequirement: XPCClientRequirement? = nil
-        for client in authorizedClients {
-            var requirement: SecRequirement?
-            guard SecRequirementCreateWithString(client as CFString, SecCSFlags(), &requirement) == errSecSuccess,
-                  let requirement = requirement else {
-                throw XPCError.misconfiguredServer(description: "Invalid SMAuthorizedClients requirement: \(client)")
-            }
-            
-            if let currentRequirement = clientRequirement {
-                clientRequirement = currentRequirement || .secRequirement(requirement)
-            } else {
-                clientRequirement = .secRequirement(requirement)
-            }
-        }
-        guard let clientRequirement = clientRequirement else {
-            throw XPCError.misconfiguredServer(description: "No requirements were generated from SMAuthorizedClients")
-        }
-
-        return try getXPCMachServer(named: machServiceName, clientRequirement: clientRequirement)
-    }
-
-    /// Read the property list embedded within this helper tool.
-    ///
-    /// - Returns: The property list as data.
-    private static func readEmbeddedPropertyList(sectionName: String) throws -> Data {
-        // By passing in nil, this returns a handle for the dynamic shared object (shared library) for this helper tool
-        guard let handle = dlopen(nil, RTLD_LAZY) else {
-            throw XPCError.misconfiguredServer(description: "Could not read property list (handle not openable)")
-        }
-        defer { dlclose(handle) }
-        
-        guard let mhExecutePointer = dlsym(handle, MH_EXECUTE_SYM) else {
-            throw XPCError.misconfiguredServer(description: "Could not read property list (nil symbol pointer)")
-        }
-        let mhExecuteBoundPointer = mhExecutePointer.assumingMemoryBound(to: mach_header_64.self)
-
-        var size = UInt()
-        guard let section = getsectiondata(mhExecuteBoundPointer, "__TEXT", sectionName, &size) else {
-            throw XPCError.misconfiguredServer(description: "Missing property list section \(sectionName)")
-        }
-        
-        return Data(bytes: section, count: Int(size))
-    }
-    
-    // MARK: daemon & agent
-    
-    private static func parentAppURL() throws -> URL {
-        let components = Bundle.main.bundleURL.pathComponents
-        guard let contentsIndex = components.lastIndex(of: "Contents"),
-              components[components.index(before: contentsIndex)].hasSuffix(".app") else {
-            throw XPCError.misconfiguredServer(description: "Parent bundle could not be found")
-        }
-        
-        return URL(fileURLWithPath: "/" + components[1..<contentsIndex].joined(separator: "/"))
-    }
-    
-    // directoryName is expected to be one of:
-    // - LaunchDaemons
-    // - LaunchAgents
-    private static func plistsForDaemonOrAgent(parentURL: URL, directoryName: String) throws -> [[String : Any]] {
-        // For a daemon, from Apple:
-        //   The property list name must correspond to a property list in the calling app’s
-        //   Contents/Library/LaunchDaemons directory
-        //
-        // For an agent, from Apple:
-        //   The property list name must correspond to a property list in the calling app’s
-        //   Contents/Library/LaunchAgents directory.
-        guard let executableURL = Bundle.main.executableURL else {
-            throw XPCError.misconfiguredServer(description: "This process lacks an executable URL")
-        }
-        let plistDirectory = parentURL.appendingPathComponent("Contents", isDirectory: true)
-                                      .appendingPathComponent("Library", isDirectory: true)
-                                      .appendingPathComponent(directoryName, isDirectory: true)
-        let plistDirectoryContents = try FileManager.default.contentsOfDirectory(at: plistDirectory,
-                                                                                 includingPropertiesForKeys: nil)
-        let plistsData = plistDirectoryContents.compactMap { try? Data(contentsOf: $0) }
-        let plists = plistsData.compactMap {
-            try? PropertyListSerialization.propertyList(from: $0, format: nil) as? [String : Any]
-        }
-        let matchingPlists = plists.filter {
-            guard let bundleProgram = $0["BundleProgram"] as? String else {
-                return false
-            }
-            return URL(string: bundleProgram, relativeTo: parentURL)?.absoluteURL == executableURL
-        }
-        
-        return matchingPlists
-    }
-    
-    private static func machServices(propertyLists: [[String : Any]]) throws -> Set<String> {
-        Set<String>(propertyLists.flatMap { ($0["MachServices"] as? [String : Any] ?? [:]).keys })
-    }
-    
-    private static func machServiceNameForAgentOrDaemon() throws -> String {
-        let parentURL = try parentAppURL()
-        let plists = try plistsForDaemonOrAgent(parentURL: parentURL, directoryName: "LaunchDaemons")
-        let serviceNames = try machServices(propertyLists: plists)
-
-        // We can't actually know which property list was used to register this service, so if there are multiple
-        // conflicting ones we need to fail (and of course also fail if there are none). The same applies if there was
-        // only one property list, but it had multiple MachServices entries.
-        guard serviceNames.count == 1, let serviceName = serviceNames.first else {
-            if serviceNames.isEmpty {
-                throw XPCError.misconfiguredServer(description: "No property lists for had a MachServices entry")
-            } else {
-                throw XPCError.misconfiguredServer(description: "Multiple MachServices keys found: \(serviceNames)")
-            }
-        }
-        
-        return serviceName
-    }
-    
-    // MARK: daemon
-    
-    internal static var isThisProcessADaemon: Bool {
-        guard let parentURL = try? parentAppURL(),
-              let machServices = try? plistsForDaemonOrAgent(parentURL: parentURL, directoryName: "LaunchDaemons") else {
-            return false
-        }
-        
-        return !machServices.isEmpty
-    }
-    
-    internal static func forThisDaemon() throws -> XPCMachServer {
-        let serviceName = try machServiceNameForAgentOrDaemon()
-
-        // Use the parent's designated requirement as the criteria for the message acceptor. An alternative approach
-        // would be to use the same approach as Login Item where we allow anything in the parent's bundle with the same
-        // team identifier to communicate with this daemon, but considering the considerable privilege escalation
-        // potential this intentionally takes a more restricted approach.
-        let clientRequirement = try XPCClientRequirement.parentDesignatedRequirement
-        
-        return try getXPCMachServer(named: serviceName, clientRequirement: clientRequirement)
-    }
-    
-    // MARK: agent
-    
-    internal static var isThisProcessAnAgent: Bool {
-        guard let parentURL = try? parentAppURL(),
-              let machServices = try? plistsForDaemonOrAgent(parentURL: parentURL, directoryName: "LaunchAgents") else {
-            return false
-        }
-        
-        return !machServices.isEmpty
-    }
-    
-    internal static func forThisAgent() throws -> XPCMachServer {
-        let serviceName = try machServiceNameForAgentOrDaemon()
-
-        // Use the team identifier as the criteria for the message acceptor. An alternative approach would be to use
-        // the parent's designated requirement or restrict to within the parent's app bundle, but if either of those
-        // were the desired use case for this launch agent then in most cases an XPC service would be a better fit. If a
-        // launch agent is being used it's reasonable to default to allowing requests from outside of the app bundle as
-        // long as it's from the same team identifier.
-        let clientRequirement = try XPCClientRequirement.sameTeamIdentifier
-        
-        return try getXPCMachServer(named: serviceName, clientRequirement: clientRequirement)
-    }
-    
-    // MARK: Login Item
-    
-    internal static var isThisProcessALoginItem: Bool {
-        // Login item must be a bundle
-        let loginItem = Bundle.main.bundleURL
-        guard loginItem.pathExtension == "app" else {
-            return false
-        }
-        
-        // Login item must be within the main bundle's Contents/Library/LoginItems directory
-        let pathComponents = loginItem.deletingLastPathComponent().pathComponents
-        guard pathComponents.count >= 3, pathComponents.suffix(3) == ["Contents", "Library", "LoginItems"] else {
-            return false
-        }
-        
-        return true
-    }
-    
-    internal static func forThisLoginItem() throws -> XPCMachServer {
-        guard let teamIdentifier = try teamIdentifierForThisProcess() else {
-            throw XPCError.misconfiguredServer(description: """
-            A login item must have a team identifier in order to enable secure communication.
-            """)
-        }
-        try validateIsLoginItem(teamIdentifier: teamIdentifier)
-        
-        // From Apple's AppSandboxLoginItemXPCDemo:
-        // https://developer.apple.com/library/archive/samplecode/AppSandboxLoginItemXPCDemo/
-        //     LaunchServices implicitly registers a Mach service for the login item whose name is the same as the
-        //     login item's bundle identifier.
-        guard let bundleID = Bundle.main.bundleIdentifier else {
-            throw XPCError.misconfiguredServer(description: """
-            The bundle identifier is missing; login items must have one.
-            """)
-        }
-        let clientRequirement: XPCClientRequirement = try .teamIdentifier(teamIdentifier) || .sameParentBundle
-        
-        return try getXPCMachServer(named: bundleID, clientRequirement: clientRequirement)
-    }
-    
-    private static func validateIsLoginItem(teamIdentifier: String) throws {
-        guard isThisProcessALoginItem else {
-            throw XPCError.misconfiguredServer(description: """
-            A login item must be an app bundle located within its parent bundle's Contents/Library/LoginItems directory.
-            Path:\(Bundle.main.bundleURL)
-            """)
-        }
-        
-        if try isSandboxed() {
-            // If this process is sandboxed, then the login item *must* have an application group entitlement in order
-            // to enable XPC communication. (Non-sandboxed apps cannot have one as this entitlement only applies to the
-            // sandbox - it's not part of the hardened runtime.)
-            let entitlementName = "com.apple.security.application-groups"
-            
-            let entitlement = try readEntitlement(name: entitlementName)
-            guard let entitlement = entitlement else {
-                throw XPCError.misconfiguredServer(description: """
-                Application groups entitlement \(entitlementName) is missing, but must be  present for a sandboxed \
-                login item to communicate over XPC.
-                """)
-            }
-            guard CFGetTypeID(entitlement) == CFArrayGetTypeID(), let entitlement = (entitlement as? NSArray) else {
-                throw XPCError.misconfiguredServer(description: """
-                Application groups entitlement \(entitlementName) must be an array of strings.
-                """)
-            }
-            let appGroups = try entitlement.map { (element: NSArray.Element) throws -> String in
-                guard let elementAsString = element as? String else {
-                    throw XPCError.misconfiguredServer(description: """
-                    Application groups entitlement \(entitlementName) must be an array of strings.
-                    """)
-                }
-                
-                return elementAsString
-            }
-            
-            // From https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_security_application-groups
-            //     For macOS the format is: <team identifier>.<group name>
-            //
-            // So for XPC communication to succeed at least one app group must start with this login item's team
-            // identifier followed by a period.
-            if !appGroups.contains(where: { $0.starts(with: "\(teamIdentifier).") }) {
-                throw XPCError.misconfiguredServer(description: """
-                Application groups entitlement \(entitlementName) must contain at least one application group for team \
-                identifier \(teamIdentifier).
-                """)
-            }
         }
     }
 }

--- a/Sources/SecureXPC/Server/XPCServiceServer.swift
+++ b/Sources/SecureXPC/Server/XPCServiceServer.swift
@@ -15,7 +15,8 @@ internal class XPCServiceServer: XPCServer {
     internal static var isThisProcessAnXPCService: Bool {
         // To be an XPC service this process needs to have a package type of XPC!, have an xpc file extension, and be
         // located in its parent's Contents/XPCServices directory
-        return mainBundlePackageInfo().packageType == "XPC!" &&
+        // See https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/CreatingXPCServices.html#//apple_ref/doc/uid/10000172i-SW6-SW6
+        mainBundlePackageInfo().packageType == "XPC!" &&
         Bundle.main.bundleURL.pathExtension == "xpc" &&
         Bundle.main.bundleURL.deletingLastPathComponent().pathComponents.suffix(2) == ["Contents", "XPCServices"]
     }
@@ -32,10 +33,7 @@ internal class XPCServiceServer: XPCServer {
     /// Connections received for the anonymous listener connection while the server is not started
     private var pendingConnections = [xpc_connection_t]()
         
-    internal static func forThisXPCService() throws -> XPCServiceServer {
-        // An XPC service's package type must be equal to "XPC!", see Apple's documentation for details
-        // https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/CreatingXPCServices.html#//apple_ref/doc/uid/10000172i-SW6-SW6
-        
+    internal static func getXPCServiceServer() throws -> XPCServiceServer {
         guard isThisProcessAnXPCService else {
             throw XPCError.misconfiguredServer(description: """
             This process is not an XPC service.


### PR DESCRIPTION
This conceptually partially reverts the decision to make retrieving an `XPCServer` (aside from anonymous ones) all happen as part of one function. Implementation wise this is quite different than before as will be described.

The three functions are:
1. `forThisXPCService()` - nothing too interest, basically does what it says on the tin
2. `forMachService()` - this function is where a lot of goodness/magic happens, it basically returns a fully configured `XPCServer` for a Mach service so long as it conforms to one of four the built-in types and only has one Mach service present
3. `forMachService(withCriteria:)` - this is a highly customizable variant of 2 which makes use of the new `XPCServer.MachServiceCriteria` and can support any type of Mach service.

All of this is built with the principle of progressive disclosure, so I expect most API users will never use the third function and that's fine.

One thing worth noting that I realized was wrong with the previous design is that it's perfectly valid for a helper tool to provide multiple XPC Mach services simultaneously. As such it's essential to have access to the non-blocking `start()` function and it's quite useful to be able to still have auto-configured client requirements while specifying just the name of the service, which can now be done with `XPCServer.MachServiceCriteria`.

A nice internal side effect of these changes is that `XPCMachServer` now does not concern itself with all of the various built-in types, that's all factored out into `XPCServer.MachServiceCriteria`.