### PR TITLE
More efficient representations of `Data` and some array types

### DIFF
--- a/Sources/SecureXPC/Codable Property Wrappers/ArrayOptimizedForXPC.swift
+++ b/Sources/SecureXPC/Codable Property Wrappers/ArrayOptimizedForXPC.swift
@@ -1,0 +1,136 @@
+//
+//  ArrayOptimizedForXPC.swift
+//  SecureXPC
+//
+//  Created by Josh Kaplan on 2022-07-19
+//
+
+import Foundation
+
+/// Wraps an array to optimize how it is sent over an XPC connection.
+///
+/// Arrays of the following type are supported by this property wrapper: `Bool`, `Double`, `Float`, `UInt`, `UInt8`, `UInt16`, `UInt32`, `UInt64`,
+/// `Int`, `Int8`, `Int16`, `Int32`, and `Int64`.
+///
+/// Usage of this property wrapper is never required and has no benefit when the array is either the message or reply type for an ``XPCRoute``.  When transferring
+/// a type which _contains_ an array property it is more efficient both in runtime and memory usage to wrap it using this property wrapper.
+@propertyWrapper public struct ArrayOptimizedForXPC<Element: XPCOptimizableArrayElement> {
+    public var wrappedValue: [Element]
+    
+    public init(wrappedValue: [Element]) {
+        self.wrappedValue = wrappedValue
+    }
+}
+
+// MARK: Codable
+
+extension ArrayOptimizedForXPC: Encodable {
+    public func encode(to encoder: Encoder) throws {
+        let xpcEncoder = try XPCEncoderImpl.asXPCEncoderImpl(encoder)
+        guard let data = encodeArrayAsData(value: self.wrappedValue) else {
+            let debugDescription = "Unable to encode \(self.wrappedValue.self) to XPC data represetation"
+            let context = EncodingError.Context(codingPath: encoder.codingPath,
+                                                debugDescription: debugDescription,
+                                                underlyingError: nil)
+            throw EncodingError.invalidValue(self.wrappedValue, context)
+        }
+        
+        xpcEncoder.xpcSingleValueContainer().setAlreadyEncodedValue(data)
+    }
+}
+
+extension ArrayOptimizedForXPC: Decodable {
+    public init(from decoder: Decoder) throws {
+        let xpcDecoder = try XPCDecoderImpl.asXPCDecoderImpl(decoder)
+        let container = xpcDecoder.xpcSingleValueContainer()
+        guard let array = decodeDataAsArray(arrayType: [Element].self, arrayAsData: container.value) else {
+            let debugDescription = "Unable to decode \(container.value.description) to an array of type \(Element.self)"
+            let context = DecodingError.Context(codingPath: container.codingPath,
+                                                debugDescription: debugDescription,
+                                                underlyingError: nil)
+            throw DecodingError.dataCorrupted(context)
+        }
+        
+        self.wrappedValue = array
+    }
+}
+
+// MARK: Helper functions
+
+internal func encodeArrayAsData(value: Any) -> xpc_object_t? {
+    func directEncodeArray<E>(_ array: [E]) -> xpc_object_t {
+        array.withUnsafeBytes { xpc_data_create($0.baseAddress, array.count * MemoryLayout<E>.stride) }
+    }
+    
+    if let array = value as? [Bool] {   return directEncodeArray(array) }
+    if let array = value as? [Double] { return directEncodeArray(array) }
+    if let array = value as? [Float] {  return directEncodeArray(array) }
+    if let array = value as? [UInt] {   return directEncodeArray(array) }
+    if let array = value as? [UInt8] {  return directEncodeArray(array) }
+    if let array = value as? [UInt16] { return directEncodeArray(array) }
+    if let array = value as? [UInt32] { return directEncodeArray(array) }
+    if let array = value as? [UInt64] { return directEncodeArray(array) }
+    if let array = value as? [Int] {    return directEncodeArray(array) }
+    if let array = value as? [Int8] {   return directEncodeArray(array) }
+    if let array = value as? [Int16] {  return directEncodeArray(array) }
+    if let array = value as? [Int32] {  return directEncodeArray(array) }
+    if let array = value as? [Int64] {  return directEncodeArray(array) }
+    
+    return nil
+}
+
+internal func decodeDataAsArray<T>(arrayType: T.Type, arrayAsData: xpc_object_t) -> T? {
+    func directDecodeArray<E>(_ pointer: UnsafeRawPointer, length: Int, type: E.Type) -> [E] {
+        let count = length / MemoryLayout<E>.stride
+        let boundPointer = pointer.bindMemory(to: E.self, capacity: count)
+        let bufferPoint = UnsafeBufferPointer(start: boundPointer, count: count)
+        
+        return Array<E>(bufferPoint)
+    }
+    
+    guard xpc_get_type(arrayAsData) == XPC_TYPE_DATA else {
+        return nil
+    }
+    
+    guard let pointer = xpc_data_get_bytes_ptr(arrayAsData) else {
+        return nil
+    }
+    let length = xpc_data_get_length(arrayAsData)
+    
+    if arrayType == [Bool].self {   return directDecodeArray(pointer, length: length, type: Bool.self) as? T }
+    if arrayType == [Double].self { return directDecodeArray(pointer, length: length, type: Double.self) as? T }
+    if arrayType == [Float].self {  return directDecodeArray(pointer, length: length, type: Float.self) as? T }
+    if arrayType == [UInt].self {   return directDecodeArray(pointer, length: length, type: UInt.self) as? T }
+    if arrayType == [UInt8].self {  return directDecodeArray(pointer, length: length, type: UInt8.self) as? T }
+    if arrayType == [UInt16].self { return directDecodeArray(pointer, length: length, type: UInt16.self) as? T }
+    if arrayType == [UInt32].self { return directDecodeArray(pointer, length: length, type: UInt32.self) as? T }
+    if arrayType == [UInt64].self { return directDecodeArray(pointer, length: length, type: UInt64.self) as? T }
+    if arrayType == [Int].self {    return directDecodeArray(pointer, length: length, type: Int.self) as? T }
+    if arrayType == [Int8].self {   return directDecodeArray(pointer, length: length, type: Int8.self) as? T }
+    if arrayType == [Int16].self {  return directDecodeArray(pointer, length: length, type: Int16.self) as? T }
+    if arrayType == [Int32].self {  return directDecodeArray(pointer, length: length, type: Int32.self) as? T }
+    if arrayType == [Int64].self {  return directDecodeArray(pointer, length: length, type: Int64.self) as? T }
+    
+    return nil
+}
+
+// MARK: type constraining protocol
+
+/// Constrains the array elements supported by ``ArrayOptimizedForXPC``.
+///
+/// >Warning: Do not implement this protocol.
+public protocol XPCOptimizableArrayElement: Codable { }
+
+extension Bool: XPCOptimizableArrayElement {}
+extension Double: XPCOptimizableArrayElement {}
+extension Float: XPCOptimizableArrayElement {}
+extension UInt: XPCOptimizableArrayElement {}
+extension UInt8: XPCOptimizableArrayElement {}
+extension UInt16: XPCOptimizableArrayElement {}
+extension UInt32: XPCOptimizableArrayElement {}
+extension UInt64: XPCOptimizableArrayElement {}
+extension Int: XPCOptimizableArrayElement {}
+extension Int8: XPCOptimizableArrayElement {}
+extension Int16: XPCOptimizableArrayElement {}
+extension Int32: XPCOptimizableArrayElement {}
+extension Int64: XPCOptimizableArrayElement {}

--- a/Sources/SecureXPC/Codable Property Wrappers/DataOptimizedForXPC.swift
+++ b/Sources/SecureXPC/Codable Property Wrappers/DataOptimizedForXPC.swift
@@ -1,0 +1,49 @@
+//
+//  DataOptimizedForXPC.swift
+//  SecureXPC
+//
+//  Created by Josh Kaplan on 2022-07-19
+//
+
+import Foundation
+
+
+/// Wraps a [`Data`](https://developer.apple.com/documentation/foundation/data) instance to optimize how it is sent over an XPC connection.
+///
+/// Usage of this property wrapper is never required and has no benefit when `Data` is either the message or reply type for an ``XPCRoute``.  When transferring
+/// a type which _contains_ a `Data` property it is more efficient both in runtime and memory usage to wrap it using this property wrapper.
+@propertyWrapper public struct DataOptimizedForXPC {
+    public var wrappedValue: Data
+    
+    public init(wrappedValue: Data) {
+        self.wrappedValue = wrappedValue
+    }
+}
+
+// MARK: Codable
+
+extension DataOptimizedForXPC: Encodable {
+    public func encode(to encoder: Encoder) throws {
+        let xpcEncoder = try XPCEncoderImpl.asXPCEncoderImpl(encoder)
+        let encodedValue = wrappedValue.withUnsafeBytes { xpc_data_create($0.baseAddress, self.wrappedValue.count) }
+        xpcEncoder.xpcSingleValueContainer().setAlreadyEncodedValue(encodedValue)
+    }
+}
+
+extension DataOptimizedForXPC: Decodable {
+    public init(from decoder: Decoder) throws {
+        let xpcDecoder = try XPCDecoderImpl.asXPCDecoderImpl(decoder)
+        let container = xpcDecoder.xpcSingleValueContainer()
+        let value = container.value
+        
+        guard xpc_get_type(value) == XPC_TYPE_DATA, let pointer = xpc_data_get_bytes_ptr(value) else {
+            let debugDescription = "Unable to decode \(container.value.description) to \(Data.self) instance"
+            let context = DecodingError.Context(codingPath: container.codingPath,
+                                                debugDescription: debugDescription,
+                                                underlyingError: nil)
+            throw DecodingError.dataCorrupted(context)
+        }
+        
+        self.wrappedValue = Data(bytes: pointer, count: xpc_data_get_length(value))
+    }
+}

--- a/Sources/SecureXPC/Codable Property Wrappers/IOSurfaceForXPC.swift
+++ b/Sources/SecureXPC/Codable Property Wrappers/IOSurfaceForXPC.swift
@@ -9,6 +9,9 @@ import Foundation
 import IOSurface
 
 /// Wraps an [`IOSurface`](https://developer.apple.com/documentation/iosurface) such that it can be sent over an XPC connection.
+///
+/// When creating an ``XPCRoute`` that directly transfers this type as either the message or reply type, `IOSurfaceForXPC` must be the specified type, not
+/// `IOSurface`. This is not applicable when transferring a type which _contains_ a wrapped `IOSurface` as one of its properties.
 @available(macOS 10.12, *)
 @propertyWrapper public struct IOSurfaceForXPC {
     public var wrappedValue: IOSurface

--- a/Sources/SecureXPC/SecureXPC.docc/SecureXPC.md
+++ b/Sources/SecureXPC/SecureXPC.docc/SecureXPC.md
@@ -111,3 +111,8 @@ See ``XPCClient`` for more on how to retrieve a client and send requests.
 - ``FileDescriptorForXPC``
 - ``POSIXFileDescriptorForXPC``
 - ``IOSurfaceForXPC``
+- ``DataOptimizedForXPC``
+- ``ArrayOptimizedForXPC``
+
+### Misc
+- ``XPCOptimizableArrayElement``

--- a/Tests/SecureXPCTests/Encoder & Decoder/Round Trip/ArrayOptimizedForXPC Tests.swift
+++ b/Tests/SecureXPCTests/Encoder & Decoder/Round Trip/ArrayOptimizedForXPC Tests.swift
@@ -1,0 +1,32 @@
+//
+//  ArrayOptimizedForXPCTests.swift
+//  SecureXPC
+//
+//  Created by Josh Kaplan on 2022-07-19
+//
+
+import Foundation
+import XCTest
+import SecureXPC
+
+final class ArrayOptimizedForXPCTests: XCTestCase {
+    struct Info: Codable {
+        let description: String
+        @ArrayOptimizedForXPC var array: [Int]
+    }
+    
+    func testRoundTrip() async throws {
+        let array = [1, 1, 2, 3, 5, 8, 13]
+        let server = XPCServer.makeAnonymous()
+        let client = XPCClient.forEndpoint(server.endpoint)
+        let route = XPCRoute.named("one", "info", "please")
+                            .withReplyType(Info.self)
+        server.registerRoute(route) {
+            return Info(description: "This is your info", array: array)
+        }
+        server.start()
+        
+        let info = try await client.send(to: route)
+        XCTAssertEqual(info.array, array)
+    }
+}

--- a/Tests/SecureXPCTests/Encoder & Decoder/Round Trip/DataOptimizedForXPC Tests.swift
+++ b/Tests/SecureXPCTests/Encoder & Decoder/Round Trip/DataOptimizedForXPC Tests.swift
@@ -1,0 +1,32 @@
+//
+//  DataOptimizedForXPCTests.swift
+//  SecureXPC
+//
+//  Created by Josh Kaplan on 2022-07-19
+//
+
+import Foundation
+import XCTest
+import SecureXPC
+
+final class DataOptimizedForXPCTests: XCTestCase {
+    struct Info: Codable {
+        let description: String
+        @DataOptimizedForXPC var data: Data
+    }
+    
+    func testRoundTrip() async throws {
+        let data = Data(base64Encoded: "QWxsIHlvdXIgYmFzZSBhcmUgYmVsb25nIHRvIHVz")!
+        let server = XPCServer.makeAnonymous()
+        let client = XPCClient.forEndpoint(server.endpoint)
+        let route = XPCRoute.named("one", "info", "please")
+                            .withReplyType(Info.self)
+        server.registerRoute(route) {
+            return Info(description: "This is your info", data: data)
+        }
+        server.start()
+        
+        let info = try await client.send(to: route)
+        XCTAssertEqual(info.data, data)
+    }
+}


### PR DESCRIPTION
Resolves #7 by directly encoding/decoding `Data` to its XPC equivalent when it's the route reply or message type or enables an equally efficient encoding via an optional property wrapper.

The same is done for arrays of `Bool` and all standard numeric types.