### PR TITLE
Dynamically creates a launch agent to facilitate testing

### DIFF
--- a/Tests/SecureXPCTests/Multiprocess Client & Server/LaunchAgent Tests.swift
+++ b/Tests/SecureXPCTests/Multiprocess Client & Server/LaunchAgent Tests.swift
@@ -1,0 +1,72 @@
+//
+//  LaunchAgentTests.swift
+//  SecureXPC
+//
+//  Created by Josh Kaplan on 2022-07-22
+//
+
+import Foundation
+import SecureXPC
+import XCTest
+
+// By default the set up to run these tests takes a *long* time as it builds an entire launch agent from scratch and
+// then loads it. The most time consuming part of this by far is that it builds all of SecureXPC from source.
+//
+// It is possible to bypass this step and specify the path to your pre-built SecureXPC.o module. If you're using Xcode
+// then this will be located at:
+//  /Users/<username>/Library/Developer/Xcode/DerivedData/<project>-<random letters>/Build/Products/Debug/SecureXPC.o
+//
+// Where <project> is the name of the project that you included SecureXPC as a dependency.
+//
+// On a 16" Intel MacBook Pro, providing a pre-built module reduces set up time from ~25 seconds down to 1 second.
+final class LaunchAgentTests: XCTestCase {
+    
+    static var launchAgent: LaunchAgent!
+    static var client: XPCClient!
+    
+    // Called once before all tests in this class are run
+    override class func setUp() {
+        super.setUp()
+        
+        // To provide a pre-built SecureXPC module, specify the URL as the module path
+        let modulePath: URL? = nil
+        if modulePath == nil {
+            print("""
+            \(LaunchAgentTests.self) is compiling SecureXPC from source. To speed this up, specify the path to the \
+            SecureXPC.o module file in your Xcode DerivedData folder. See code comments for details.
+            """)
+        }
+        launchAgent = try! LaunchAgent.setUp(existingSecureXPCModule: modulePath)
+        client = XPCClient.forMachService(named: launchAgent.machServiceName)
+    }
+    
+    // Called once after all tests in this class are run
+    override class func tearDown() {
+        super.tearDown()
+        try! launchAgent.tearDown()
+    }
+    
+    // This test exists primarily to validate that all of the set up actually worked properly
+    func testBasicRoundTrip() async throws {
+        let message = "Anyone home?"
+        let reply = try await LaunchAgentTests.client.sendMessage(message, to: SharedRoutes.echoRoute)
+        
+        XCTAssertEqual(message, reply)
+    }
+    
+    func testMutateSharedMemory() async throws {
+        // This isn't the best example for how shared memory ought to typically be used since it involves explicit XPC
+        // calls to actually mutate the shared value, but it's an easy way to test it's working properly
+        let reply = try await LaunchAgentTests.client.send(to: SharedRoutes.latestRoute)
+        
+        let initialNow = reply.now
+        let initialValue = reply.latestValue
+        
+        try await LaunchAgentTests.client.send(to: SharedRoutes.mutateLatestRoute)
+        let subsequentNow = reply.now
+        let subsequentValue = reply.latestValue
+        
+        XCTAssertNotEqual(initialNow, subsequentNow)
+        XCTAssertNotEqual(initialValue, subsequentValue)
+    }
+}

--- a/Tests/SecureXPCTests/Multiprocess Client & Server/LaunchAgent Tests.swift
+++ b/Tests/SecureXPCTests/Multiprocess Client & Server/LaunchAgent Tests.swift
@@ -1,5 +1,5 @@
 //
-//  LaunchAgentTests.swift
+//  LaunchAgent Tests.swift
 //  SecureXPC
 //
 //  Created by Josh Kaplan on 2022-07-22

--- a/Tests/SecureXPCTests/Multiprocess Client & Server/LaunchAgent/LaunchAgent.swift
+++ b/Tests/SecureXPCTests/Multiprocess Client & Server/LaunchAgent/LaunchAgent.swift
@@ -1,0 +1,185 @@
+//
+//  LaunchAgent.swift
+//  SecureXPC
+//
+//  Created by Josh Kaplan on 2022-07-23
+//
+
+import Foundation
+
+/// The entry point for interacting with a launch agent which runs the code in `main.swift` (and `Shared.swift`) and links against the SecureXPC module.
+struct LaunchAgent {
+    let machServiceName: String
+    private let temporaryDirectory: URL
+    private let launchdPropertyList: URL
+    
+    static func setUp(existingSecureXPCModule: URL?) throws -> LaunchAgent {
+        let workingDirectory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: workingDirectory,
+                                                withIntermediateDirectories: false,
+                                                attributes: nil)
+        
+        // Use the path to the SecureXPC module if one was provide, otherwise compile from source
+        let moduleDefinitionDirectory: URL
+        let secureXPCPath: URL
+        if let existingSecureXPCModule = existingSecureXPCModule {
+            moduleDefinitionDirectory = existingSecureXPCModule.deletingLastPathComponent()
+            secureXPCPath = existingSecureXPCModule
+        } else {
+            moduleDefinitionDirectory = workingDirectory
+            secureXPCPath = try compileSecureXPC(workingDirectory: workingDirectory)
+        }
+        
+        // Don't use `.` in the name as this will be the same name for the Swift module and `.` is not a valid character
+        // for a Swift module
+        let executableName = "SecureXPC_Test_\(UUID().uuidString.replacingOccurrences(of: "-", with: ""))"
+        let executablePath = try compileLaunchAgent(executableName: executableName,
+                                                    workingDirectory: workingDirectory,
+                                                    moduleDefinitionDirectory: moduleDefinitionDirectory,
+                                                    secureXPCModule: secureXPCPath)
+        // Use the name of the executable as the mach service name as that provides a convenient way to have a
+        // dynamically generated service name which the launch agent can derive at run time
+        let launchdPropertyList = try loadLaunchAgent(executablePath: executablePath, machServiceName: executableName)
+        
+        return LaunchAgent(machServiceName: executableName,
+                           temporaryDirectory: workingDirectory,
+                           launchdPropertyList: launchdPropertyList)
+    }
+    
+    func tearDown() throws {
+        try LaunchAgent.unloadLaunchAgent(plistLocation: self.launchdPropertyList)
+        try FileManager.default.removeItem(at: self.temporaryDirectory)
+    }
+    
+    // MARK: implementation
+    
+    /// The path to this source file
+    private static func currentPath(filePath: String = #filePath) -> String { filePath }
+    
+    /// The path to the directory containing SecureXPC's sources
+    private static func sourcesPath(filePath: String = #filePath) -> URL {
+        let currentURL = URL(fileURLWithPath: filePath)
+        let components = currentURL.pathComponents
+        guard let testsIndex = components.lastIndex(of: "Tests"),
+              components[components.index(before: testsIndex)] == "SecureXPC" else {
+            fatalError("Unable to find Tests directory in SecureXPC directory")
+        }
+        
+        return URL(fileURLWithPath: "/" + components[1..<testsIndex].joined(separator: "/") + "/Sources")
+    }
+    
+    /// Compiles SecureXPC, returning the path to static library `libSecureXPC.a`
+    private static func compileSecureXPC(workingDirectory: URL) throws -> URL {
+        // SecureXPC's source files (which are all .swift)
+        let enumerator = FileManager.default.enumerator(at: sourcesPath(), includingPropertiesForKeys: nil)!
+        let swiftPaths = enumerator.compactMap { (file: Any) -> String? in
+            if let file = file as? URL, file.lastPathComponent.hasSuffix(".swift") {
+                return file.path
+            }
+    
+            return nil
+        }
+        
+        // Compile as a library
+        let compileProcess = createSwiftcProcess()
+        compileProcess.currentDirectoryURL = workingDirectory
+        var compileArgs = ["-c"]
+        compileArgs.append(contentsOf: swiftPaths )
+        compileArgs.append(contentsOf: ["-parse-as-library", "-module-name", "SecureXPC"])
+        compileProcess.arguments = compileArgs
+        try compileProcess.run()
+        compileProcess.waitUntilExit()
+        
+        // Create the module information and static library
+        let emitProcess = createSwiftcProcess()
+        emitProcess.currentDirectoryURL = workingDirectory
+        var emitArgs = ["-emit-module", "-emit-library", "-static"]
+        emitArgs.append(contentsOf: swiftPaths )
+        emitArgs.append(contentsOf: ["-module-name", "SecureXPC"])
+        emitProcess.arguments = emitArgs
+        try emitProcess.run()
+        emitProcess.waitUntilExit()
+        
+        return workingDirectory.appendingPathComponent("libSecureXPC.a")
+    }
+    
+    private static func compileLaunchAgent(
+        executableName: String,
+        workingDirectory: URL,
+        moduleDefinitionDirectory: URL,
+        secureXPCModule: URL
+    ) throws -> URL {
+        // The launch agent is expected to consist of the main.swift and Shared.swift files in this folder
+        let mainURL = URL(fileURLWithPath: currentPath()).deletingLastPathComponent()
+                                                         .appendingPathComponent("main.swift")
+        let sharedURL = URL(fileURLWithPath: currentPath()).deletingLastPathComponent()
+                                                           .appendingPathComponent("Shared.swift")
+        
+        // Compile, but don't link
+        let compileProcess = createSwiftcProcess()
+        compileProcess.currentDirectoryURL = workingDirectory
+        compileProcess.arguments = ["-c", mainURL.path, sharedURL.path,
+                                    "-module-name", executableName,
+                                    "-I", moduleDefinitionDirectory.path]
+        try compileProcess.run()
+        compileProcess.waitUntilExit()
+        
+        // Link
+        let linkProcess = createSwiftcProcess()
+        linkProcess.currentDirectoryURL = workingDirectory
+        linkProcess.arguments = ["-emit-executable", "main.o", "Shared.o", secureXPCModule.path, "-o", executableName]
+        try linkProcess.run()
+        linkProcess.waitUntilExit()
+        
+        return workingDirectory.appendingPathComponent(executableName)
+    }
+    
+    private static func createSwiftcProcess() -> Process {
+        let process = Process()
+        process.launchPath = "/usr/bin/swiftc"
+        
+        // See https://stackoverflow.com/questions/67595371/
+        if ProcessInfo.processInfo.environment.keys.contains("OS_ACTIVITY_DT_MODE") {
+            var env = ProcessInfo.processInfo.environment
+            env["OS_ACTIVITY_DT_MODE"] = nil
+            process.environment = env
+        }
+        
+        return process
+    }
+    
+    /// Uses `launchctl`  to load the launch agent, returning the URL to the property list used to load it
+    private static func loadLaunchAgent(executablePath: URL, machServiceName: String) throws -> URL {
+        // Create property list
+        let plistLocation = executablePath.deletingLastPathComponent()
+                                          .appendingPathComponent(executablePath.lastPathComponent + ".plist")
+        if FileManager.default.fileExists(atPath: plistLocation.path) {
+            try unloadLaunchAgent(plistLocation: plistLocation)
+        }
+        let plist: [String : AnyHashable] = [
+            "Label" : executablePath.lastPathComponent,
+            "Program" : executablePath.path,
+            "MachServices": [machServiceName : true]
+        ]
+        let plistData = try PropertyListSerialization.data(fromPropertyList: plist, format: .xml, options: 0)
+        try plistData.write(to: plistLocation)
+
+        // Load
+        let launchctlProcess = Process()
+        launchctlProcess.launchPath = "/bin/launchctl"
+        launchctlProcess.arguments = ["load", plistLocation.path]
+        try launchctlProcess.run()
+        launchctlProcess.waitUntilExit()
+        
+        return plistLocation
+    }
+    
+    /// Uses `launchctl`  to unload the launch agent
+    private static func unloadLaunchAgent(plistLocation: URL) throws {
+        let launchctlProcess = Process()
+        launchctlProcess.launchPath = "/bin/launchctl"
+        launchctlProcess.arguments = ["unload", plistLocation.path]
+        try launchctlProcess.run()
+        launchctlProcess.waitUntilExit()
+    }
+}

--- a/Tests/SecureXPCTests/Multiprocess Client & Server/LaunchAgent/Shared.swift
+++ b/Tests/SecureXPCTests/Multiprocess Client & Server/LaunchAgent/Shared.swift
@@ -1,0 +1,26 @@
+//
+//  Shared.swift
+//  SecureXPC
+//
+//  Created by Josh Kaplan on 2022-07-23
+//
+
+import Foundation
+import SecureXPC
+
+// This file is both compiled into the launch agent created by LaunchAgent.swift and referenced by main.swift as well as
+// accessible from the SecureXPC tests - specificaly it's used in "LaunchAgent Tests.swift"
+
+struct SharedRoutes {
+    static let echoRoute = XPCRoute.named("echo")
+                                   .withMessageType(String.self)
+                                   .withReplyType(String.self)
+    static let latestRoute = XPCRoute.named("retrieve", "latest")
+                                     .withReplyType(LatestAndGreatest.self)
+    static let mutateLatestRoute = XPCRoute.named("mutate", "latest")
+}
+
+struct LatestAndGreatest: Codable {
+    @SharedTrivial var now: CFAbsoluteTime
+    @SharedTrivial var latestValue: Double
+}

--- a/Tests/SecureXPCTests/Multiprocess Client & Server/LaunchAgent/main.swift
+++ b/Tests/SecureXPCTests/Multiprocess Client & Server/LaunchAgent/main.swift
@@ -1,0 +1,36 @@
+//
+//  main.swift
+//  SecureXPC
+//
+//  Created by Josh Kaplan on 2022-07-23
+//
+
+import Foundation
+import SecureXPC
+
+let server = try createServer()
+
+server.registerRoute(SharedRoutes.echoRoute) { $0 }
+
+var latestAndGreatest = LatestAndGreatest(now: CFAbsoluteTimeGetCurrent(), latestValue: Double.random(in: 0.0...1000.0))
+server.registerRoute(SharedRoutes.latestRoute) { latestAndGreatest }
+server.registerRoute(SharedRoutes.mutateLatestRoute) {
+    latestAndGreatest.now = CFAbsoluteTimeGetCurrent()
+    latestAndGreatest.latestValue += Double.random(in: 0.0...1000.0)
+}
+
+server.startAndBlock()
+
+func createServer() throws -> XPCServer {
+    // To simplify things while having a dynamically generated Mach service name, the name is the name of this executable
+    let machServiceName = URL(fileURLWithPath: CommandLine.arguments.first!).lastPathComponent
+
+    // This is a useless security requirement which essentially allows any client to connect, unless it happens to have
+    // an Info.plist entry called `VeryUnlikelyThisWouldEverExist`
+    var requirement: SecRequirement?
+    SecRequirementCreateWithString("!info [VeryUnlikelyThisWouldEverExist] exists" as CFString, [], &requirement)
+    let criteria = XPCServer.MachServiceCriteria(machServiceName: machServiceName,
+                                                 clientRequirement: .secRequirement(requirement!))
+
+    return try XPCServer.forMachService(withCriteria: criteria)
+}

--- a/Tests/SecureXPCTests/Multiprocess Client & Server/LaunchAgent/main.swift
+++ b/Tests/SecureXPCTests/Multiprocess Client & Server/LaunchAgent/main.swift
@@ -8,6 +8,9 @@
 import Foundation
 import SecureXPC
 
+// This code run as a launch agent, which is created by LaunchAgent.swift.
+// Make sure to only reference SecureXPC and Shared.swift; anything else will fail when compiling.
+
 let server = try createServer()
 
 server.registerRoute(SharedRoutes.echoRoute) { $0 }


### PR DESCRIPTION
A launch agent running as a completely separate process is now created, registered (load) with `launchd`, and can be communicated with. This allows for testing shared memory functionality in a separate process.

Cleanup logic also exists to unload the agent and delete all of the created files. However, the paths and service name are all randomly generated, so nothing bad ought to happen if cleanup fails (for example because a test fails).

Building SecureXPC from scratch takes a long time, so the code has been written in such a way that people using this framework can provide a path to the pre-built module - this will speed things up about 25x.

For reference, these were helpful resources in figuring out how to use `swiftc`:
- https://theswiftdev.com/building-static-and-dynamic-swift-libraries-using-the-swift-compiler/
- https://blog.spencerkohan.com/building-swift-without-a-build-system/