### PR TITLE
Interrupted connections finish async sequences, addresses discussion #122

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ xcuserdata/
 DerivedData/
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .swiftpm/xcode/xcshareddata/xcschemes/SecureXPCTests.xcscheme
+*.xcscheme

--- a/Sources/SecureXPC/Client/XPCClient.swift
+++ b/Sources/SecureXPC/Client/XPCClient.swift
@@ -541,7 +541,6 @@ public class XPCClient {
                 } else {
                     continuation.finish(throwing: error)
                 }
-                continuation.finish(throwing: error)
             case .finished:
                 continuation.finish(throwing: nil)
         }

--- a/Sources/SecureXPC/SequentialResultProvider.swift
+++ b/Sources/SecureXPC/SequentialResultProvider.swift
@@ -19,20 +19,35 @@ import Foundation
 ///
 /// Any errors generated while using this provider will be passed to the ``XPCServer``'s error handler.
 ///
+/// All results sent to the client including finishing a sequence are enqueued and sent asynchronously. For example a call to ``success(value:onDelivery:)``
+/// may return before the result has actually been sent. To determine whether the client has actually received the result either call the `async` version such as
+/// ``success(value:)`` or pass a ``SequentialResultDeliveryHandler`` to  ``success(value:onDelivery:)``. This can be particularly
+/// useful in applying back pressure to the system to prevent the client from accumulating too many yet to be processed results. However, if this behavior is not
+/// needed then do not use the `async` versions as `await`ing them will always wait on client delivery (unless an error occurs).
+///
 /// Once a sequence has been either explicitly finished or finishes because of an encoding error, any subsequent operations will not be sent and
 /// ``XPCError/sequenceFinished`` will be passed to the error handler. If a sequence was not already finished, it will be finished upon deinitialization of this
 /// provider instance.
 ///
-/// While provider instances are thread-safe, attempting concurrent responses is likely to lead to inconsistent ordering on the client side. If exact ordering is
-/// necessary, it is recommended that callers synchronize access to a provider instance.
+/// While provider instances are thread-safe, attempting concurrent responses may lead to inconsistent ordering on the client side. If exact ordering is necessary, it is
+/// recommended that callers synchronize access to a provider instance.
 ///
 /// ## Topics
-/// ### Responding
+/// ### Responding with Optional Closures
+/// - ``respond(withResult:onDelivery:)``
+/// - ``success(value:onDelivery:)``
+/// ### Finishing with Optional Closures
+/// - ``finished(onDelivery:)``
+/// - ``failure(error:onDelivery:)``
+/// ### Delivery Closure
+/// - ``SequentialResultDeliveryHandler``
+/// ### Responding with Async
 /// - ``respond(withResult:)``
 /// - ``success(value:)``
-/// ### Finishing
+/// ### Finishing with Async
 /// - ``finished()``
 /// - ``failure(error:)``
+/// ### State
 /// - ``isFinished``
 public class SequentialResultProvider<S: Encodable> {
     private let request: Request
@@ -40,12 +55,19 @@ public class SequentialResultProvider<S: Encodable> {
     private weak var connection: xpc_connection_t?
     private let serialQueue: DispatchQueue
     
+    /// Invoked upon delivery of a result to a client, or failure to do so.
+    ///
+    /// If the result was not delivered successfully, the associated error will be provided to this handler. The error will also be provided to the ``XPCServer``'s
+    /// error handler.
+    public typealias SequentialResultDeliveryHandler = (Result<Void, XPCError>) -> Void
+    
     /// Whether this provider has finished replying with results.
     ///
     /// Once a provider is finished, calling any of its functions will result in ``XPCError/sequenceFinished`` and the response not being sent.
     ///
-    /// This will be `true` if ``finished()`` or ``failure(error:)`` have been called or ``respond(withResult:)`` was passed
-    /// ``SequentialResult/finished`` or ``SequentialResult/failure(_:)``.
+    /// This will be `true` if ``finished(onDelivery:)`` or ``failure(error:onDelivery:)`` have been called or
+    /// ``respond(withResult:onDelivery:)`` was passed ``SequentialResult/finished`` or ``SequentialResult/failure(_:)``.
+    /// However, this will not necessarily be `true` immediately after one of those functions return as finishing a sequence is processed asynchronously.
     public private(set) var isFinished: Bool
     
     init(request: Request, server: XPCServer, connection: xpc_connection_t) {
@@ -77,52 +99,125 @@ public class SequentialResultProvider<S: Encodable> {
     
     /// Responds to the client with the provided result.
     ///
-    /// - Parameter result: The sequential result to respond with.
-    public func respond(withResult result: SequentialResult<S, Error>) {
+    /// - Parameters:
+    ///   -   result: The sequential result to respond with.
+    ///   -   deliveryHandler: Invoked upon succesful delivery of the result to the client or failure to do so.
+    public func respond(
+        withResult result: SequentialResult<S, Error>,
+        onDelivery deliveryHandler: SequentialResultDeliveryHandler? = nil
+    ) {
         switch result {
             case .success(let value):
-                self.success(value: value)
+                self.success(value: value, onDelivery: deliveryHandler)
             case .failure(let error):
-                self.failure(error: error)
+                self.failure(error: error, onDelivery: deliveryHandler)
             case .finished:
                 self.finished()
         }
     }
     
+    /// Responds to the client with the provided result and waits for it to be handled.
+    ///
+    /// - Parameters:
+    ///   -   result: The sequential result to respond with.
+    @available(macOS 10.15, *)
+    public func respond(withResult result: SequentialResult<S, Error>) async throws {
+        try await withUnsafeThrowingContinuation { continuation in
+            self.respond(withResult: result) { continuation.resume(with: $0) }
+        }
+    }
+    
     /// Responds to the client with the provided value.
     ///
-    /// - Parameter value: The value to be sent.
-    public func success(value: S) {
-        self.sendResponse(isFinished: false) { response in
+    /// - Parameters:
+    ///   -   value: The value to be sent.
+    ///   -   deliveryHandler: Invoked upon succesful delivery of the value to the client or failure to do so.
+    public func success(value: S, onDelivery deliveryHandler: SequentialResultDeliveryHandler? = nil) {
+        self.sendResponse(isFinished: false, onDelivery: deliveryHandler) { response in
             try Response.encodePayload(value, intoReply: &response)
         }
     }
     
-    /// Responds to the client with the provided error and finishes the sequence.
+    /// Responds to the client with the provided value and waits for it to be handled.
+    /// 
+    /// This is equivalent to ``success(value:onDelivery:)`` and providing a ``SequentialResultDeliveryHandler`` meaning that awaiting this
+    /// function call will wait on the client to have handled the value provided to this function. If there is no need to wait on the client (for example in order to rate
+    /// limit sending new sequential reply values) then use ``success(value:onDelivery:)`` and pass `nil` for the delivery handler.
+    ///
+    /// - Parameters:
+    ///   -   value: The value to be sent.
+    @available(macOS 10.15, *)
+    public func success(value: S) async throws {
+        try await withUnsafeThrowingContinuation { continuation in
+            self.success(value: value) { continuation.resume(with: $0) }
+        }
+    }
+    
+    /// Responds to the client with the error and finishes the sequence.
     ///
     /// This error will also be passed to the ``XPCServer``'s error handler if one has been set.
     ///
-    /// - Parameter error: The error to be sent to the client and passed to the server's error handler.
-    public func failure(error: Error) {
+    /// - Parameters:
+    ///   -   error: The error to be sent to the client and passed to the server's error handler.
+    ///   -   deliveryHandler: Invoked upon succesful delivery of the error to the client or failure to do so.
+    public func failure(error: Error, onDelivery deliveryHandler: SequentialResultDeliveryHandler? = nil) {
         let handlerError = HandlerError(error: error)
         self.sendToServerErrorHandler(handlerError)
         
-        self.sendResponse(isFinished: true) { response in
+        self.sendResponse(isFinished: true, onDelivery: deliveryHandler) { response in
             try Response.encodeError(XPCError.handlerError(handlerError), intoReply: &response)
         }
     }
     
-    /// Responds to the client indicating the sequence is now finished.
+    /// Responds to the client with the error, finishes the sequence, and waits for it to be handled.
     ///
-    /// If a sequence was not already finished, it will be finished upon deinitialization of this provider.
-    public func finished() {
-        // An "empty" response indicates it's finished
-        self.sendResponse(isFinished: true) { _ in }
+    /// This error will also be passed to the ``XPCServer``'s error handler if one has been set.
+    ///
+    /// This is equivalent to ``failure(error:onDelivery:)`` and providing a ``SequentialResultDeliveryHandler`` meaning that awaiting this
+    /// function call will wait on the client to have handled the error provided to this function.
+    ///
+    /// - Parameters:
+    ///   -   error: The error to be sent to the client and passed to the server's error handler.
+    @available(macOS 10.15, *)
+    public func failure(error: Error) async throws {
+        try await withUnsafeThrowingContinuation { continuation in
+            self.failure(error: error) { continuation.resume(with: $0) }
+        }
     }
     
-    private func sendResponse(isFinished: Bool, encodingWork: @escaping (inout xpc_object_t) throws -> Void) {
+    /// Responds to the client indicating the sequence is finished.
+    ///
+    /// If a sequence was not already finished, it will be finished upon deinitialization of this provider.
+    ///
+    /// - Parameters:
+    ///   -   deliveryHandler: Invoked upon succesful completion of the sequence on the client side or failure to do so.
+    public func finished(onDelivery deliveryHandler: SequentialResultDeliveryHandler? = nil) {
+        // An "empty" response indicates it's finished
+        self.sendResponse(isFinished: true, onDelivery: deliveryHandler) { _ in }
+    }
+    
+    /// Responds to the client indicating the sequence is finished and waits for it to be handled.
+    ///
+    /// If a sequence was not already finished, it will be finished upon deinitialization of this provider.
+    ///
+    /// This is equivalent to ``finished(onDelivery:)`` and providing a ``SequentialResultDeliveryHandler`` meaning that awaiting this
+    /// function call will wait on the client to have handled the sequence finishing.
+    ///
+    @available(macOS 10.15, *)
+    public func finished() async throws {
+        try await withUnsafeThrowingContinuation { continuation in
+            self.finished() { continuation.resume(with: $0) }
+        }
+    }
+    
+    private func sendResponse(
+        isFinished: Bool,
+        onDelivery deliveryHandler: SequentialResultDeliveryHandler?,
+        encodingWork: @escaping (inout xpc_object_t) throws -> Void
+    ) {
         self.serialQueue.async {
             if self.isFinished {
+                deliveryHandler?(.failure(XPCError.sequenceFinished))
                 self.sendToServerErrorHandler(XPCError.sequenceFinished)
                 return
             }
@@ -130,6 +225,7 @@ public class SequentialResultProvider<S: Encodable> {
             self.isFinished = isFinished
             
             guard let connection = self.connection else {
+                deliveryHandler?(.failure(XPCError.clientNotConnected))
                 self.sendToServerErrorHandler(XPCError.clientNotConnected)
                 return
             }
@@ -140,8 +236,15 @@ public class SequentialResultProvider<S: Encodable> {
                 
                 do {
                     try encodingWork(&response)
-                    xpc_connection_send_message(connection, response)
+                    if let deliveryHandler = deliveryHandler {
+                        xpc_connection_send_message_with_reply(connection, response, nil) { _ in
+                            deliveryHandler(.success(()))
+                        }
+                    } else {
+                        xpc_connection_send_message(connection, response)
+                    }
                 } catch {
+                    deliveryHandler?(.failure(XPCError.asXPCError(error: error)))
                     self.sendToServerErrorHandler(error)
                     
                     do {
@@ -157,6 +260,7 @@ public class SequentialResultProvider<S: Encodable> {
             } catch {
                 // If we're not able to encode the requestID, there's no point sending back a response as the client
                 // wouldn't be able to make use of it
+                deliveryHandler?(.failure(XPCError.asXPCError(error: error)))
                 self.sendToServerErrorHandler(error)
             }
             

--- a/Sources/SecureXPC/SequentialResultProvider.swift
+++ b/Sources/SecureXPC/SequentialResultProvider.swift
@@ -15,7 +15,8 @@ import Foundation
 /// - Synchronous without a message — ``XPCServer/registerRoute(_:handler:)-7r1hv``
 /// - Synchronous with a message — ``XPCServer/registerRoute(_:handler:)-qcox``
 ///
-/// It is valid to use an instance of this class outside of the closure it was provided to. Responses will be sent so long as the client remains connected.
+/// It is valid to use an instance of this class outside of the closure it was provided to. Responses will be sent so long as the client remains connected and the
+/// sequence has not already been finished.
 ///
 /// Any errors generated while using this provider will be passed to the ``XPCServer``'s error handler.
 ///
@@ -94,6 +95,8 @@ public class SequentialResultProvider<S: Encodable> {
                 // There's no point trying to send the encoding error to the client because encoding the requestID
                 // failed and that's needed by the client in order to properly reassociate the error with the request
             }
+            
+            self.endTransaction()
         }
     }
     
@@ -202,7 +205,6 @@ public class SequentialResultProvider<S: Encodable> {
     ///
     /// This is equivalent to ``finished(onDelivery:)`` and providing a ``SequentialResultDeliveryHandler`` meaning that awaiting this
     /// function call will wait on the client to have handled the sequence finishing.
-    ///
     @available(macOS 10.15, *)
     public func finished() async throws {
         try await withUnsafeThrowingContinuation { continuation in

--- a/Sources/SecureXPC/Server/XPCServer.swift
+++ b/Sources/SecureXPC/Server/XPCServer.swift
@@ -98,6 +98,12 @@ import Foundation
 /// server.start()
 /// ```
 ///
+/// ### Terminating a Process Containing a Server
+/// There is intentionally no way to stop an `XPCServer` once it has been started. Of course it is possible to terminate the containing process; however, it is
+/// recommend you avoid doing this as it introduces more opportunities for race conditions. For example, if the process containing the server terminates itself after
+/// handling a request from a client, there is a possibility that a subsequent request will be received by the server process before termination has completed meaning
+/// it will nearly instantly fail with an ``XPCError/connectionInterrupted`` error. Allow launchd to automatically manage the lifecycle of your service.
+///
 /// ## Topics
 /// ### Retrieving a Server
 /// - ``forThisXPCService()``

--- a/Tests/SecureXPCTests/Multiprocess Client & Server/LaunchAgent Tests.swift
+++ b/Tests/SecureXPCTests/Multiprocess Client & Server/LaunchAgent Tests.swift
@@ -69,4 +69,44 @@ final class LaunchAgentTests: XCTestCase {
         XCTAssertNotEqual(initialNow, subsequentNow)
         XCTAssertNotEqual(initialValue, subsequentValue)
     }
+    
+    func testAsyncSequenceInterruptedByServerTermination() async throws {
+        // This test is validating that an async sequence will throw an error if the server process exits before the
+        // sequence finishes. A request is made to the server to generate the first ten values of the Fibonacci
+        // sequence, but once the fifth value (which is 3) is received, a message is sent to the server telling it to
+        // terminate.
+    
+        // This is the _minimum_ set of expected values from the server; however, it's valid for additional values to
+        // be received beyond this because the termination request is inherently racing against the server sending the
+        // next value in the sequence. (This behavior is intentional to more closely resemble real conditions, not a
+        // flaw in the test's design.)
+        var expectedValues: [UInt] = [0, 1, 1, 2, 3]
+        
+        do {
+            for try await value in LaunchAgentTests.client.sendMessage(10, to: SharedRoutes.fibonacciRoute) {
+                // Already received all of the expected values, but it's still valid to receive more due to racing
+                // against process termination
+                if expectedValues.isEmpty {
+                    continue
+                }
+                
+                XCTAssertEqual(expectedValues.removeFirst(), value)
+                if value == 3 {
+                    LaunchAgentTests.client.send(to: SharedRoutes.terminate, onCompletion: nil)
+                }
+            }
+            
+            XCTFail("No error was thrown when server process exited, \(XPCError.connectionInterrupted) was expected.")
+        } catch {
+            // Once all of the expected valeus have been received, XPCError.connectionInterrupted error is now expected
+            if !expectedValues.isEmpty {
+                XCTFail("\(error) received but one or more expected values were not received first: \(expectedValues)")
+            }
+            else if case XPCError.connectionInterrupted = error {
+                // Expected case
+            } else {
+                XCTFail("Unexpected error \(error) received. \(XPCError.connectionInterrupted) was expected.")
+            }
+        }
+    }
 }

--- a/Tests/SecureXPCTests/Multiprocess Client & Server/LaunchAgent Tests.swift
+++ b/Tests/SecureXPCTests/Multiprocess Client & Server/LaunchAgent Tests.swift
@@ -109,4 +109,13 @@ final class LaunchAgentTests: XCTestCase {
             }
         }
     }
+    
+    func testAsyncSequenceFullyReceivedBeforeServerTermination() async throws {
+        // This test is validating that an async sequence will not be terminated due the server process terminating
+        // immediately after it finishes the sequence.
+        var expectedValues: [UInt] = [0, 1, 1, 2, 3]
+        for try await value in LaunchAgentTests.client.sendMessage(5, to: SharedRoutes.selfTerminatingFibonacciRoute) {
+            XCTAssertEqual(expectedValues.removeFirst(), value)
+        }
+    }
 }

--- a/Tests/SecureXPCTests/Multiprocess Client & Server/LaunchAgent/LaunchAgent.swift
+++ b/Tests/SecureXPCTests/Multiprocess Client & Server/LaunchAgent/LaunchAgent.swift
@@ -69,6 +69,8 @@ struct LaunchAgent {
     }
     
     /// Compiles SecureXPC, returning the path to static library `libSecureXPC.a`
+    ///
+    /// This requires Xcode command line developer tools to be installed; this is distinct from having Xcode itself installed.
     private static func compileSecureXPC(workingDirectory: URL) throws -> URL {
         // SecureXPC's source files (which are all .swift)
         let enumerator = FileManager.default.enumerator(at: sourcesPath(), includingPropertiesForKeys: nil)!

--- a/Tests/SecureXPCTests/Multiprocess Client & Server/LaunchAgent/Shared.swift
+++ b/Tests/SecureXPCTests/Multiprocess Client & Server/LaunchAgent/Shared.swift
@@ -22,6 +22,9 @@ struct SharedRoutes {
     static let fibonacciRoute = XPCRoute.named("fibonacci")
                                         .withMessageType(UInt.self)
                                         .withSequentialReplyType(UInt.self)
+    static let selfTerminatingFibonacciRoute = XPCRoute.named("fibonacci", "self-terminating")
+                                                       .withMessageType(UInt.self)
+                                                       .withSequentialReplyType(UInt.self)
 }
 
  struct LatestAndGreatest: Codable {

--- a/Tests/SecureXPCTests/Multiprocess Client & Server/LaunchAgent/Shared.swift
+++ b/Tests/SecureXPCTests/Multiprocess Client & Server/LaunchAgent/Shared.swift
@@ -18,6 +18,10 @@ struct SharedRoutes {
     static let latestRoute = XPCRoute.named("retrieve", "latest")
                                      .withReplyType(LatestAndGreatest.self)
     static let mutateLatestRoute = XPCRoute.named("mutate", "latest")
+    static let terminate = XPCRoute.named("terminate")
+    static let fibonacciRoute = XPCRoute.named("fibonacci")
+                                        .withMessageType(UInt.self)
+                                        .withSequentialReplyType(UInt.self)
 }
 
  struct LatestAndGreatest: Codable {

--- a/Tests/SecureXPCTests/Multiprocess Client & Server/LaunchAgent/main.swift
+++ b/Tests/SecureXPCTests/Multiprocess Client & Server/LaunchAgent/main.swift
@@ -8,7 +8,7 @@
 import Foundation
 import SecureXPC
 
-// This code run as a launch agent, which is created by LaunchAgent.swift.
+// This code runs as a launch agent, which is created by LaunchAgent.swift.
 // Make sure to only reference SecureXPC and Shared.swift; anything else will fail when compiling.
 
 let server = try createServer()
@@ -28,62 +28,15 @@ server.registerRoute(SharedRoutes.terminate) {
     exit(0)
 }
 server.registerRoute(SharedRoutes.fibonacciRoute) { n, provider in
-    let artificialDelay = 0.001
-    
-    if n >= 1 {
-        provider.success(value: 0)
-        Thread.sleep(forTimeInterval: artificialDelay)
-    }
-    
-    if n >= 2 {
-        provider.success(value: 1)
-        Thread.sleep(forTimeInterval: artificialDelay)
-    }
-    
-    if n >= 3 {
-        var prev: UInt = 0
-        var current: UInt = 1
-        
-        for _ in 2..<n {
-            let lastCurrent = current
-            current = current + prev
-            prev = lastCurrent
-            provider.success(value: current)
-            Thread.sleep(forTimeInterval: artificialDelay)
-        }
-    }
-    
+    fibonacciSequence(n: n, provider: provider)
     provider.finished()
 }
 
 server.registerRoute(SharedRoutes.selfTerminatingFibonacciRoute) { n, provider in
-    let artificialDelay = 0.001
-    
-    if n >= 1 {
-        provider.success(value: 0)
-        Thread.sleep(forTimeInterval: artificialDelay)
+    fibonacciSequence(n: n, provider: provider)
+    provider.finished { _ in
+        exit(0)
     }
-    
-    if n >= 2 {
-        provider.success(value: 1)
-        Thread.sleep(forTimeInterval: artificialDelay)
-    }
-    
-    if n >= 3 {
-        var prev: UInt = 0
-        var current: UInt = 1
-        
-        for _ in 2..<n {
-            let lastCurrent = current
-            current = current + prev
-            prev = lastCurrent
-            provider.success(value: current)
-            Thread.sleep(forTimeInterval: artificialDelay)
-        }
-    }
-    
-    provider.finished()
-    exit(0)
 }
 
 server.startAndBlock()
@@ -100,4 +53,31 @@ func createServer() throws -> XPCServer {
                                                  clientRequirement: .secRequirement(requirement!))
 
     return try XPCServer.forMachService(withCriteria: criteria)
+}
+
+func fibonacciSequence(n: UInt, provider: SequentialResultProvider<UInt>) {
+    let artificialDelay = 0.001
+    
+    if n >= 1 {
+        provider.success(value: 0)
+        Thread.sleep(forTimeInterval: artificialDelay)
+    }
+    
+    if n >= 2 {
+        provider.success(value: 1)
+        Thread.sleep(forTimeInterval: artificialDelay)
+    }
+    
+    if n >= 3 {
+        var prev: UInt = 0
+        var current: UInt = 1
+        
+        for _ in 2..<n {
+            let lastCurrent = current
+            current = current + prev
+            prev = lastCurrent
+            provider.success(value: current)
+            Thread.sleep(forTimeInterval: artificialDelay)
+        }
+    }
 }

--- a/Tests/SecureXPCTests/Multiprocess Client & Server/LaunchAgent/main.swift
+++ b/Tests/SecureXPCTests/Multiprocess Client & Server/LaunchAgent/main.swift
@@ -56,6 +56,36 @@ server.registerRoute(SharedRoutes.fibonacciRoute) { n, provider in
     provider.finished()
 }
 
+server.registerRoute(SharedRoutes.selfTerminatingFibonacciRoute) { n, provider in
+    let artificialDelay = 0.001
+    
+    if n >= 1 {
+        provider.success(value: 0)
+        Thread.sleep(forTimeInterval: artificialDelay)
+    }
+    
+    if n >= 2 {
+        provider.success(value: 1)
+        Thread.sleep(forTimeInterval: artificialDelay)
+    }
+    
+    if n >= 3 {
+        var prev: UInt = 0
+        var current: UInt = 1
+        
+        for _ in 2..<n {
+            let lastCurrent = current
+            current = current + prev
+            prev = lastCurrent
+            provider.success(value: current)
+            Thread.sleep(forTimeInterval: artificialDelay)
+        }
+    }
+    
+    provider.finished()
+    exit(0)
+}
+
 server.startAndBlock()
 
 func createServer() throws -> XPCServer {

--- a/Tests/SecureXPCTests/Multiprocess Client & Server/LaunchAgent/main.swift
+++ b/Tests/SecureXPCTests/Multiprocess Client & Server/LaunchAgent/main.swift
@@ -24,6 +24,38 @@ server.registerRoute(SharedRoutes.mutateLatestRoute) {
     try latestAndGreatest.latestValue.updateValue(nextValue)
 }
 
+server.registerRoute(SharedRoutes.terminate) {
+    exit(0)
+}
+server.registerRoute(SharedRoutes.fibonacciRoute) { n, provider in
+    let artificialDelay = 0.001
+    
+    if n >= 1 {
+        provider.success(value: 0)
+        Thread.sleep(forTimeInterval: artificialDelay)
+    }
+    
+    if n >= 2 {
+        provider.success(value: 1)
+        Thread.sleep(forTimeInterval: artificialDelay)
+    }
+    
+    if n >= 3 {
+        var prev: UInt = 0
+        var current: UInt = 1
+        
+        for _ in 2..<n {
+            let lastCurrent = current
+            current = current + prev
+            prev = lastCurrent
+            provider.success(value: current)
+            Thread.sleep(forTimeInterval: artificialDelay)
+        }
+    }
+    
+    provider.finished()
+}
+
 server.startAndBlock()
 
 func createServer() throws -> XPCServer {


### PR DESCRIPTION
For a given `XPCClient` all active async sequences are terminated with an error if the connection with the server is interrupted. This is the correct behavior because no more responses can possibly be received for this given sequence (although a new requests could be made and might succeed if the server is successfully started once again).