### PR TITLE
Small tweaks to hardenedRuntime client requirement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ xcuserdata/
 DerivedData/
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .swiftpm/xcode/xcshareddata/xcschemes/SecureXPCTests.xcscheme
+*.xcscheme


### PR DESCRIPTION
Importantly adds a minimum macOS 10.14 requirement as the runtime flag (as well as the Hardened Runtime itself) did not exist prior to this verison.