### PR TITLE
Fixes #128 - consistently determines location of CLI or app bundle

### DIFF
--- a/Sources/SecureXPC/Server/ClientRequirement.swift
+++ b/Sources/SecureXPC/Server/ClientRequirement.swift
@@ -142,10 +142,10 @@ extension XPCServer.ClientRequirement {
     
     private static var parentBundleURL: URL {
         get throws {
-            let components = Bundle.main.bundleURL.pathComponents
+            let components = currentExecutableOrAppBundleURL().pathComponents
             guard let contentsIndex = components.lastIndex(of: "Contents") else {
                 throw XPCError.misconfiguredServer(description: "This server does not have a parent bundle.\n" +
-                                                                "Path components: \(components)")
+                                                                "Components: \(components)")
             }
             
             return URL(fileURLWithPath: "/" + components[1..<contentsIndex].joined(separator: "/"))

--- a/Sources/SecureXPC/Server/MachServiceCriteria.swift
+++ b/Sources/SecureXPC/Server/MachServiceCriteria.swift
@@ -499,12 +499,12 @@ private func throwIfSandboxedAndThisLoginItemCannotCommunicateOverXPC() throws {
 // MARK: SMAppService daemon & agent
 
 private func parentAppURL() throws -> URL {
-    let components = Bundle.main.bundleURL.pathComponents
+    let components = currentExecutableOrAppBundleURL().pathComponents
     guard let contentsIndex = components.lastIndex(of: "Contents"),
           components[components.index(before: contentsIndex)].hasSuffix(".app") else {
         throw XPCError.misconfiguredServer(description: """
         Parent bundle could not be found.
-        Path:\(Bundle.main.bundleURL)
+        Components: \(components)
         """)
     }
     
@@ -565,6 +565,7 @@ private func validateThisProcessIsAnSMAppServiceDaemon() -> ValidationResult {
         return .failure("""
         An SMAppService daemon must have a property list within its parent bundle's Contents/Library/LaunchDaemons /
         directory.
+        Parent bundle: \(try! parentAppURL())
         """)
     }
     


### PR DESCRIPTION
This a rather complex fix as it turns out `Bundle.main.bundleURL` behaves differently for helper tools located within an `.app` bundle if they're located in `Contents/MacOS/` vs `Contents/Resources/`. In the case of `Contents/MacOS/` which I had previously never tested, the `bundleURL` returned is for the entire bundle while for the `Contents/Resources/` case it returns a path to `Resources`.

This by itself wouldn't be too complicated because in these cases `Bundle.main.executableURL` will return a path to itself. However it's valid for a `SMAppService` agent or daemon to _be_ an app bundle (and not just a command line tool) and we need to differentiate this situation otherwise it wouldn't be possible to identify the parent bundle.

Additionally it's valid for the case where the helper tool isn't in a bundle at all in which case `Bundle.main.executableURL` isn't applicable. As such `_NSGetExecutablePath` was used to consistently derive a path.