### PR TITLE
Check reply status

### DIFF
--- a/Sources/SecureXPC/SequentialResultProvider.swift
+++ b/Sources/SecureXPC/SequentialResultProvider.swift
@@ -239,8 +239,12 @@ public class SequentialResultProvider<S: Encodable> {
                 do {
                     try encodingWork(&response)
                     if let deliveryHandler = deliveryHandler {
-                        xpc_connection_send_message_with_reply(connection, response, nil) { _ in
-                            deliveryHandler(.success(()))
+                        xpc_connection_send_message_with_reply(connection, response, nil) { result in
+							if xpc_get_type(result) == XPC_TYPE_ERROR {
+								deliveryHandler(.failure(XPCError.fromXPCObject(result)))
+							} else {
+								deliveryHandler(.success(()))
+							}
                         }
                     } else {
                         xpc_connection_send_message(connection, response)


### PR DESCRIPTION
When sending a reply, check if it succeed or not. If it fails, send a failure instead of a success.

Note that a unit test was causing this case, therefore I updated it.