### PR TITLE
Clear thread-local even if an error is thrown

### DIFF
--- a/Sources/SecureXPC/Server/ClientIdentity.swift
+++ b/Sources/SecureXPC/Server/ClientIdentity.swift
@@ -55,10 +55,10 @@ public extension XPCServer {
         ) rethrows -> R {
             Thread.current.threadDictionary[contextKey] = XPCServer.ClientIdentity(connection: connection,
                                                                                    message: message)
-            let result = try operation()
-            Thread.current.threadDictionary.removeObject(forKey: contextKey)
+
+            defer { Thread.current.threadDictionary.removeObject(forKey: contextKey) }
             
-            return result
+            return try operation()
         }
         
         // MARK: current context


### PR DESCRIPTION
If the `operation()` throws an error, this clean-up won't happen.

Since this thread-local will stick around, subsequent calls to `ClientIdentity.current` will be incorrect. This would let  `effectiveUserID`/`effectivegroupID`/`code` be called and return stale values, rather than `fatalError()`ing as intended.

I can't think of any immediate way to exploit this, but it's still best to just always clean it up.

